### PR TITLE
Dynamic import

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,6 +52,6 @@ SOFTWARE.
 
         
         <script src="./lib/base64js.min.js"></script>
-        <script src="./dist/bundle.js"></script>
+        <script src="./dist/main.bundle.js"></script>
     </body>
 </html>

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -425,7 +425,8 @@ export class App extends React.Component<AppProps, AppState> {
   }
   async download() {
     this.logLn("Downloading Project ...");
-    await Service.downloadProject(this.project, this.state.fiddle);
+    const downloadService = await import("../utils/download");
+    await downloadService.downloadProject(this.project, this.state.fiddle);
     this.logLn("Project Zip CREATED ");
   }
   /**

--- a/src/service.ts
+++ b/src/service.ts
@@ -25,7 +25,6 @@ import "monaco-editor";
 import { padLeft, padRight, isBranch, toAddress, decodeRestrictedBase64ToBytes } from "./util";
 import { assert } from "./index";
 import getConfig from "./config";
-import * as JSZip from "jszip";
 
 declare interface BinaryenModule {
   optimize(): any;
@@ -318,37 +317,6 @@ export class Service {
       }
     }
     return uri;
-  }
-
-  static async downloadProject(project: Project, uri?: string) {
-    const zipFile: JSZip = new JSZip();
-    let zipName: string = "download.zip";
-    if (!isUndefined(uri)) {
-      zipName = `${uri}.zip`;
-    }
-    const queue: Array<{filePrefix: string; file: File}> = [];
-    project.mapEachFile((f: File) => queue.push({filePrefix: "", file: f}));
-    while (queue.length > 0) {
-      const {filePrefix, file} = queue.shift();
-      const fileName = filePrefix + file.name;
-      if (file instanceof Directory) {
-        file.mapEachFile(f => queue.push({filePrefix: fileName + "/", file: f}));
-        zipFile.folder(fileName);
-        continue;
-      }
-      zipFile.file(fileName, file.data);
-    }
-    await zipFile.generateAsync({type: "blob", mimeType: "application/zip"}).then((blob: Blob) => {
-      // Creating <a> to programmatically click for downloading zip via blob's URL
-      const link = document.createElement("a");
-      link.download = zipName;
-      link.href = URL.createObjectURL(blob);
-      // A fix for making link clickable in Firefox
-      // Explicity adding link to DOM for Firefox
-      document.body.appendChild(link);
-      link.click();
-      document.body.removeChild(link);
-    });
   }
 
   static async exportProjectToGist(project: Project, uri?: string): Promise<string> {

--- a/src/utils/download.ts
+++ b/src/utils/download.ts
@@ -1,0 +1,55 @@
+/* Copyright 2018 Mozilla Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import { File, Project, Directory } from "../model";
+import { isUndefined } from "util";
+import * as JSZip from "jszip";
+
+export async function downloadProject(project: Project, uri?: string) {
+  const zipFile: JSZip = new JSZip();
+  let zipName: string = "download.zip";
+  if (!isUndefined(uri)) {
+    zipName = `${uri}.zip`;
+  }
+  const queue: Array<{filePrefix: string; file: File}> = [];
+  project.mapEachFile((f: File) => queue.push({filePrefix: "", file: f}));
+  while (queue.length > 0) {
+    const {filePrefix, file} = queue.shift();
+    const fileName = filePrefix + file.name;
+    if (file instanceof Directory) {
+      file.mapEachFile(f => queue.push({filePrefix: fileName + "/", file: f}));
+      zipFile.folder(fileName);
+      continue;
+    }
+    zipFile.file(fileName, file.data);
+  }
+  await zipFile.generateAsync({type: "blob", mimeType: "application/zip"}).then((blob: Blob) => {
+    // Creating <a> to programmatically click for downloading zip via blob's URL
+    const link = document.createElement("a");
+    link.download = zipName;
+    link.href = URL.createObjectURL(blob);
+    // A fix for making link clickable in Firefox
+    // Explicity adding link to DOM for Firefox
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+  });
+}

--- a/test-preprocessor.js
+++ b/test-preprocessor.js
@@ -1,5 +1,5 @@
 const tsc = require('typescript');
-const tsConfig = require('./tsconfig.json');
+const tsConfig = require('./tsconfig.test.json');
 
 module.exports = {
   process(src, path) {

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,18 +1,15 @@
 {
   "compilerOptions": {
-      "outDir": "./dist/",
-      "sourceMap": true,
       "noImplicitAny": true,
       "skipLibCheck": true,
-      "module": "esnext",
-      "moduleResolution": "node",
+      "module": "commonjs",
       "target": "es6",
       "lib": ["dom", "es6"],
       "jsx": "react",
       "declaration": true
   },
   "include": [
-      "./src/**/*"
+      "./tests/**/*"
   ],
   "exclude": [
       "./templates/**/*"

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,8 +1,12 @@
+const path = require("path");
+
 module.exports = {
   entry: "./src/index.tsx",
   output: {
-      filename: "bundle.js",
-      path: __dirname + "/dist"
+      filename: "[name].bundle.js",
+      chunkFilename: "[name].bundle.js",
+      path: path.resolve(__dirname, "dist/"),
+      publicPath: "/dist/",
   },
 
   // Enable sourcemaps for debugging webpack's output.


### PR DESCRIPTION
Associated Issue: #52

### Result

**Previous**
```
Asset     Size  Chunks                    Chunk Names
bundle.js  1.01 MB       0  [emitted]  [big]  main
bundle.js.map  1.33 MB       0  [emitted]         main
```

**Current**

```
0.bundle.js  534 kB       0  [emitted]  [big] <-- JSZip 
main.bundle.js  522 kB       1  [emitted]  [big]  main
0.bundle.js.map  652 kB       0  [emitted]
main.bundle.js.map  682 kB       1  [emitted]         main
```

### Summary of Changes

**package.json**

-> Removed build-watch

While attempting to dynamically load, having both `webpack-dev-server` and `build-watch` did cause conflicts, such as `Cannot read property 'call' of undefined at __webpack_require__`. `dev-server` will take care of the bundle distribution now for development environment.

**webpack.config.js**

Files will be served by default from `/dist/` folder.

^ Although that works, I suggest switching the whole public path onto dist/, including `index.html` (we can do that through `devServer` webpack config). This way both GHPages and dev-server wouldn't need to server everything, including source code files and configuration. For GHPages, I think it would be as simple as `cd`ing inside the `/dist` folder `before_deploy`.

**download.service.ts**

This is the main reason why of the WIP. I suggest having something like `/services`, and maybe another folder with the dynamically loaded modules, or something like that. Let me know what you think.

**tsconfig.json & tsconfig.test.json**

The previous tsconfig.json set to `target: es6` transpiled `import` to `require`. [By setting it to `esnext`](https://blog.josequinto.com/2017/06/29/dynamic-import-expressions-and-webpack-code-splitting-integration-with-typescript-2-4/#Unexpected-configuration-for-Code-Splitting-with-webpack), webpack is able to identify the `import` calls and generate the chunks.

### Test Plan

WIP
