### PR TITLE
No edit and delete option for Project

### DIFF
--- a/src/components/DirectoryTree.tsx
+++ b/src/components/DirectoryTree.tsx
@@ -154,13 +154,14 @@ export class DirectoryTree extends React.Component<DirectoryTreeProps, {
             Service.assembleWastWithWabt(file);
           }));
         }
-        actions.push(new (window as any).Action("x", "Edit", "octicon-pencil", true, () => {
-          return self.props.onEditFile && self.props.onEditFile(file as Directory);
-        }));
-        actions.push(new (window as any).Action("x", "Delete", "octicon-x", true, () => {
-          return self.props.onDeleteFile && self.props.onDeleteFile(file as Directory);
-        }));
-
+        if (!(file instanceof Project)) {
+          actions.push(new (window as any).Action("x", "Edit", "octicon-pencil", true, () => {
+            return self.props.onEditFile && self.props.onEditFile(file as Directory);
+          }));
+          actions.push(new (window as any).Action("x", "Delete", "octicon-x", true, () => {
+            return self.props.onDeleteFile && self.props.onDeleteFile(file as Directory);
+          }));
+        }
         self.contextMenuService.showContextMenu({
           getAnchor: () => anchor,
 


### PR DESCRIPTION
### Summary of Changes

* Avoided edit, delete option when target is Project

### Screenshots

* Currently, when the project is tried to be edited App breaks, no need of editing Project at all:
![Edit breaks the App](https://i.snag.gy/lfOIh9.jpg)
* Currently, when delete option is used on the project it shows an alert but doesn't work, it is better not to make it work:
![Deleting whole project](https://i.snag.gy/07Vbjh.jpg)