### PR TITLE
Tab component improvments

### DIFF
--- a/src/components/editor/Tabs.tsx
+++ b/src/components/editor/Tabs.tsx
@@ -63,14 +63,14 @@ export class Tabs extends Component<TabsProps, TabsState> {
   }
 
   onDoubleClick   = (e: MouseEvent<any>)  => { this.props.onDoubleClick(); };
-  getContainerRef = (ref: HTMLDivElement) => { this.container = ref; };
+  setContainerRef = (ref: HTMLDivElement) => { this.container = ref; };
 
   render() {
     const { onDoubleClick, children, commands } = this.props;
     return (
       <div className="tabs-container">
         <div
-          ref={this.getContainerRef}
+          ref={this.setContainerRef}
           className="tabs-tab-container"
           onWheel={this.onWheel}
           onDoubleClick={this.onDoubleClick}

--- a/src/components/editor/Tabs.tsx
+++ b/src/components/editor/Tabs.tsx
@@ -112,15 +112,27 @@ export class Tab extends PureComponent<TabProps, {}> {
     onClose: () => {},
   };
 
+  onMouseHandle = (e: MouseEvent<HTMLElement>, handler: Function) => {
+    e.stopPropagation();
+    handler(this.props.value);
+  }
+
+  onClick = (e: MouseEvent<HTMLElement>) => {
+    this.onMouseHandle(e, this.props.onClick);
+  }
+
+  onDoubleClick = (e: MouseEvent<HTMLElement>) => {
+    this.onMouseHandle(e, this.props.onDoubleClick);
+  }
+
+  onClose = (e: MouseEvent<HTMLElement>) => {
+    this.onMouseHandle(e, this.props.onClose);
+  }
+
   render() {
     const {
-      value,
       label,
       icon,
-
-      onClick,
-      onDoubleClick,
-      onClose,
 
       isActive,
       isMarked,
@@ -135,14 +147,8 @@ export class Tab extends PureComponent<TabProps, {}> {
     return (
       <div
         className={className}
-        onClick={(e: MouseEvent<HTMLElement>) => {
-          e.stopPropagation();
-          onClick(value);
-        }}
-        onDoubleClick={(e: MouseEvent<HTMLElement>) => {
-          e.stopPropagation();
-          onDoubleClick(value);
-        }}
+        onClick={this.onClick}
+        onDoubleClick={this.onDoubleClick}
       >
         {icon && <div
           className="icon"
@@ -154,10 +160,7 @@ export class Tab extends PureComponent<TabProps, {}> {
         <div className="label">{label}</div>
         <div
           className="close"
-          onClick={(e: MouseEvent<HTMLElement>) => {
-            e.stopPropagation();
-            onClose(value);
-          }}
+          onClick={this.onClose}
         />
       </div>
     );

--- a/src/components/editor/Tabs.tsx
+++ b/src/components/editor/Tabs.tsx
@@ -20,22 +20,38 @@
  */
 
 import * as React from "react";
-import { ReactElement, ReactNode, MouseEvent, WheelEvent } from "react";
+import {
+  Component,
+  PureComponent,
+  ReactElement,
+  ReactNode,
+  MouseEvent,
+  WheelEvent,
+} from "react";
 import { clamp } from "../../index";
 
-export class Tabs extends React.Component<{
+export interface TabsProps {
   onDoubleClick?: Function;
   commands?: JSX.Element | JSX.Element [];
-}, {
-    scrollLeft: number;
-  }> {
+}
+
+export interface TabsState {
+  scrollLeft: number;
+}
+
+export class Tabs extends Component<TabsProps, TabsState> {
+
+  static defaultProps: TabsProps = {
+    // tslint:disable-next-line
+    onDoubleClick: () => {},
+  };
+
   container: HTMLDivElement;
-  constructor(props: any) {
-    super(props);
-    this.state = {
-      scrollLeft: 0
-    };
-  }
+
+  state = {
+    scrollLeft: 0,
+  };
+
   onWheel = (e: WheelEvent<any>) => {
     const delta = clamp(e.deltaY, -16, 16);
     let { scrollLeft } = this.state;
@@ -46,25 +62,29 @@ export class Tabs extends React.Component<{
     e.preventDefault();
   }
 
-  onDoubleClick = (e: MouseEvent<any>) => {
-    return this.props.onDoubleClick && this.props.onDoubleClick();
-  }
+  onDoubleClick   = (e: MouseEvent<any>)  => this.props.onDoubleClick();
+  getContainerRef = (ref: HTMLDivElement) => { this.container = ref; };
 
   render() {
-    return <div className="tabs-container">
-      <div
-        ref={(ref) => { this.container = ref; }}
-        className="tabs-tab-container"
-        onWheel={this.onWheel}
-        onDoubleClick={this.onDoubleClick}
-      >
-        {this.props.children}
+    const { onDoubleClick, children, commands } = this.props;
+    return (
+      <div className="tabs-container">
+        <div
+          ref={this.getContainerRef}
+          className="tabs-tab-container"
+          onWheel={this.onWheel}
+          onDoubleClick={this.onDoubleClick}
+        >
+          {children}
+        </div>
+
+        <div className="tabs-command-container">
+          {commands}
+        </div>
       </div>
-      <div className="tabs-command-container">
-        {this.props.commands}
-      </div>
-    </div>;
+    );
   }
+
   componentDidUpdate() {
     this.container.scrollLeft = this.state.scrollLeft;
   }
@@ -82,39 +102,64 @@ export interface TabProps {
   isMarked?: boolean;
 }
 
-export class Tab extends React.Component<TabProps, {}> {
+export class Tab extends PureComponent<TabProps, {}> {
+  static defaultProps: TabProps = {
+    // tslint:disable-next-line
+    onClick: () => {},
+    // tslint:disable-next-line
+    onDoubleClick: () => {},
+    // tslint:disable-next-line
+    onClose: () => {},
+  };
+
   render() {
-    const { onClick, onDoubleClick, onClose } = this.props;
+    const {
+      value,
+      label,
+      icon,
+
+      onClick,
+      onDoubleClick,
+      onClose,
+
+      isActive,
+      isMarked,
+      isItalic,
+    } = this.props;
+
     let className = "tab";
-    if (this.props.isActive) { className += " active"; }
-    if (this.props.isMarked) { className += " marked"; }
-    if (this.props.isItalic) { className += " italic"; }
-    return <div
-      className={className}
-      onClick={(e: MouseEvent<HTMLElement>) => {
-        e.stopPropagation();
-        return onClick && onClick(this.props.value);
-      }}
-      onDoubleClick={(e: MouseEvent<HTMLElement>) => {
-        e.stopPropagation();
-        return onDoubleClick && onDoubleClick(this.props.value);
-      }}
-    >
-      {this.props.icon && <div
-        className="icon"
-        style={{
-          backgroundImage: `url(svg/${this.props.icon}.svg)`
-        }}
-      />
-      }
-      <div className="label">{this.props.label}</div>
+    if (isActive) { className += " active"; }
+    if (isMarked) { className += " marked"; }
+    if (isItalic) { className += " italic"; }
+
+    return (
       <div
-        className="close"
+        className={className}
         onClick={(e: MouseEvent<HTMLElement>) => {
           e.stopPropagation();
-          return onClose && onClose(this.props.value);
+          return onClick(value);
         }}
-      />
-    </div>;
+        onDoubleClick={(e: MouseEvent<HTMLElement>) => {
+          e.stopPropagation();
+          return onDoubleClick(value);
+        }}
+      >
+        {icon && <div
+          className="icon"
+          style={{
+            backgroundImage: `url(svg/${icon}.svg)`
+          }}
+        />
+        }
+        <div className="label">{label}</div>
+        <div
+          className="close"
+          onClick={(e: MouseEvent<HTMLElement>) => {
+            e.stopPropagation();
+            return onClose(value);
+          }}
+        />
+      </div>
+    );
   }
 }

--- a/src/components/editor/Tabs.tsx
+++ b/src/components/editor/Tabs.tsx
@@ -137,11 +137,11 @@ export class Tab extends PureComponent<TabProps, {}> {
         className={className}
         onClick={(e: MouseEvent<HTMLElement>) => {
           e.stopPropagation();
-          return onClick(value);
+          onClick(value);
         }}
         onDoubleClick={(e: MouseEvent<HTMLElement>) => {
           e.stopPropagation();
-          return onDoubleClick(value);
+          onDoubleClick(value);
         }}
       >
         {icon && <div
@@ -156,7 +156,7 @@ export class Tab extends PureComponent<TabProps, {}> {
           className="close"
           onClick={(e: MouseEvent<HTMLElement>) => {
             e.stopPropagation();
-            return onClose(value);
+            onClose(value);
           }}
         />
       </div>

--- a/src/components/editor/Tabs.tsx
+++ b/src/components/editor/Tabs.tsx
@@ -62,7 +62,7 @@ export class Tabs extends Component<TabsProps, TabsState> {
     e.preventDefault();
   }
 
-  onDoubleClick   = (e: MouseEvent<any>)  => this.props.onDoubleClick();
+  onDoubleClick   = (e: MouseEvent<any>)  => { this.props.onDoubleClick(); };
   getContainerRef = (ref: HTMLDivElement) => { this.container = ref; };
 
   render() {

--- a/src/model.ts
+++ b/src/model.ts
@@ -191,6 +191,10 @@ export function getIconForFileType(fileType: FileType): string {
     return "file_type_c";
   } else if (fileType === FileType.Cpp) {
     return "file_type_cpp";
+  } else if (fileType === FileType.Rust) {
+    return "file_type_rust";
+  } else if (fileType === FileType.Markdown) {
+    return "file_type_markdown";
   } else if (fileType === FileType.Directory) {
     return "default_folder";
   }

--- a/src/model.ts
+++ b/src/model.ts
@@ -195,6 +195,10 @@ export function getIconForFileType(fileType: FileType): string {
     return "file_type_rust";
   } else if (fileType === FileType.Markdown) {
     return "file_type_markdown";
+  } else if (fileType === FileType.HTML) {
+    return "file_type_html";
+  } else if (fileType === FileType.CSS) {
+    return "file_type_css";
   } else if (fileType === FileType.Directory) {
     return "default_folder";
   }


### PR DESCRIPTION
### Summary of Changes

* Add tab icons for Rust, Markdown, HTML & CSS
* Refactor and simplificate code for Tabs & Tab components
* Use PureComponent instead Component for Tab (performance tuning)
* Create TabsProps & TabsState and make it exportable

### Test Plan

- [x] Create Rust project for example
- [x] Select rust or markdown source file
- [x] Check if tab's icon have icon exactly for this source type

<img width="398" alt="2018-02-11 22 35 37" src="https://user-images.githubusercontent.com/1301959/36078162-ece31672-0f7b-11e8-8efc-0eef787dec76.png">