### PR TITLE
Support markdown preview

### DIFF
--- a/src/actions/AppActions.ts
+++ b/src/actions/AppActions.ts
@@ -38,9 +38,8 @@ export enum AppActionType {
   UPDATE_FILE_NAME_AND_DESCRIPTION = "UPDATE_FILE_NAME_AND_DESCRIPTION",
   DELETE_FILE = "DELETE_FILE",
   SPLIT_GROUP = "SPLIT_GROUP",
+  SHOW_PREVIEW = "SHOW_PREVIEW",
   OPEN_FILE = "OPEN_FILE",
-  CLOSE_FILE = "CLOSE_FILE",
-  SAVE_PROJECT = "SAVE_PROJECT",
   OPEN_PROJECT_FILES = "OPEN_PROJECT_FILES",
   FOCUS_TAB_GROUP = "FOCUS_TAB_GROUP",
   LOG_LN = "LOG_LN",
@@ -326,4 +325,16 @@ export async function build() {
   setStatus("Building Project ...");
   await runTask("default");
   clearStatus();
+}
+
+export interface ShowPreview extends AppAction {
+  type: AppActionType.SHOW_PREVIEW;
+  view: View;
+}
+
+export function showPreview(view: View) {
+  dispatcher.dispatch({
+    type: AppActionType.SHOW_PREVIEW,
+    view
+  } as ShowPreview);
 }

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -44,6 +44,7 @@ import {
   closeView,
   saveProject,
   focusTabGroup,
+  showPreview,
   logLn,
 } from "../actions/AppActions";
 import { Project, File, FileType, Directory, shallowCompare, ModelRef, filetypeForExtension } from "../model";
@@ -452,6 +453,7 @@ export class App extends React.Component<AppProps, AppState> {
             // TODO: Should be taken care of in shouldComponentUpdate instead.
             focusTabGroup(group);
           }}
+          onPreview={() => showPreview(group.currentView)}
           onClickView={(view: View) => {
             focusTabGroup(group);
             openView(view);

--- a/src/components/shared/Icons.tsx
+++ b/src/components/shared/Icons.tsx
@@ -155,3 +155,8 @@ export class GoClippy extends React.PureComponent {
     return <svg className="octicon octicon-clippy" viewBox="0 0 12 14" version="1.1" width="12" height="14" aria-hidden="true"><path fill-rule="evenodd" d="M2 13h4v1H2v-1zm5-6H2v1h5V7zm2 3V8l-3 3 3 3v-2h5v-2H9zM4.5 9H2v1h2.5V9zM2 12h2.5v-1H2v1zm9 1h1v2c-.02.28-.11.52-.3.7-.19.18-.42.28-.7.3H1c-.55 0-1-.45-1-1V4c0-.55.45-1 1-1h3c0-1.11.89-2 2-2 1.11 0 2 .89 2 2h3c.55 0 1 .45 1 1v5h-1V6H1v9h10v-2zM2 5h8c0-.55-.45-1-1-1H8c-.55 0-1-.45-1-1s-.45-1-1-1-1 .45-1 1-.45 1-1 1H3c-.55 0-1 .45-1 1z"/></svg>;
   }
 }
+export class GoEye extends React.PureComponent {
+  render() {
+    return <svg className="octicon octicon-eye" viewBox="0 0 16 16" version="1.1" width="16" height="16"><path d="M8.06 2C3 2 0 8 0 8s3 6 8.06 6C13 14 16 8 16 8s-3-6-7.94-6zM8 12c-2.2 0-4-1.78-4-4 0-2.2 1.8-4 4-4 2.22 0 4 1.8 4 4 0 2.22-1.78 4-4 4zm2-4c0 1.11-.89 2-2 2-1.11 0-2-.89-2-2 0-1.11.89-2 2-2 1.11 0 2 .89 2 2z" /></svg>;
+  }
+}

--- a/src/model.ts
+++ b/src/model.ts
@@ -280,6 +280,7 @@ export class File {
   type: FileType;
   data: string | ArrayBuffer;
   parent: Directory;
+  onClose?: Function;
   /**
    * True if the buffer is out of sync with the data.
    */
@@ -320,11 +321,9 @@ export class File {
       if (e.isFlush) {
         return;
       }
-      const dispatch = !this.isDirty;
+
       this.isDirty = true;
-      if (dispatch) {
-        this.notifyDidChangeBuffer();
-      }
+      this.notifyDidChangeBuffer();
       monaco.editor.setModelMarkers(this.buffer, "compiler", []);
     });
     this.parent = null;

--- a/src/stores/AppStore.ts
+++ b/src/stores/AppStore.ts
@@ -30,6 +30,7 @@ import {
   DeleteFileAction,
   UpdateFileNameAndDescriptionAction,
   LoadProjectAction,
+  ShowPreview,
   LogLnAction,
   OpenProjectFilesAction,
   FocusTabGroupAction,
@@ -223,6 +224,20 @@ export class AppStore {
     this.onTabsChange.dispatch();
   }
 
+  private showPreview(view: View) {
+    const { file } = view;
+    const newView = new View({
+      file,
+      mode: ViewMode.PREVIEW
+    });
+
+    const previewGroup = new Group(newView, [newView]);
+    this.tabGroups.push(previewGroup);
+    this.activeTabGroup = previewGroup;
+
+    this.onTabsChange.dispatch();
+  }
+
   private setStatus(status: string) {
     if (status) {
       this.project.setStatus(status);
@@ -292,6 +307,11 @@ export class AppStore {
       }
       case AppActionType.INIT_STORE: {
         this.initStore();
+        break;
+      }
+      case AppActionType.SHOW_PREVIEW: {
+        const { view } = action as ShowPreview;
+        this.showPreview(view);
         break;
       }
       case AppActionType.LOG_LN: {


### PR DESCRIPTION
Associated Issue: #17 

### Summary of Changes

* Basic support for markdown preview
* Clicking preview button opens markdown preview into another split pane
Example test plan:

- [x] Create C "hello, world" project
- [x] Open README.md
- [x] Click Preview button
- [x] Try to edit the markdown file and see changes in preview as you type

### Screenshots/Videos (OPTIONAL)
![a](https://user-images.githubusercontent.com/7821757/36086827-87a11600-0ff4-11e8-90d2-e357d895a510.gif)
