### PR TITLE
Code-explorer context option for Wasm

### DIFF
--- a/src/components/DirectoryTree.tsx
+++ b/src/components/DirectoryTree.tsx
@@ -186,6 +186,9 @@ export class DirectoryTree extends React.Component<DirectoryTreeProps, {
           actions.push(new MonacoUtils.Action("x", "To Firefox x86 Baseline", "octicon-file-binary", true, () => {
             Service.disassembleX86(file, "--wasm-always-baseline");
           }));
+          actions.push(new MonacoUtils.Action("x", "Binary Explorer", "octicon-file-binary", true, () => {
+            Service.openBinaryExplorer(file);
+          }));
         } else if (file.type === FileType.C || file.type === FileType.Cpp) {
           actions.push(new MonacoUtils.Action("x", "Clang-Format", "octicon-quote ruler", true, () => {
             Service.clangFormat(file);

--- a/src/service.ts
+++ b/src/service.ts
@@ -565,6 +565,23 @@ export class Service {
     output.setData(s);
   }
 
+  static openBinaryExplorer(file: File) {
+    const childWindow = window.open(
+      "//wasdk.github.io/wasmcodeexplorer/?api=postmessage",
+      "",
+      "toolbar=no,ocation=no,directories=no,status=no,menubar=no,location=no,scrollbars=yes,resizable=yes,width=1024,height=568"
+    );
+    window.addEventListener("message", function(e: any) {
+      if (e.data.type === "wasmexplorer-ready") {
+        const dataToSend = new Uint8Array((file.data as any).slice(0));
+        e.source.postMessage({
+          type: "wasmexplorer-load",
+          data: dataToSend
+        }, "*", [dataToSend.buffer]);
+      }
+    } , false);
+  }
+
   static async compileMarkdownToHtml(src: string): Promise<string> {
     if (typeof showdown === "undefined") {
       await Service.lazyLoad("lib/showdown.min.js");


### PR DESCRIPTION
Associated Issue: #34

### Summary of Changes

* Added context menu for inspecting Binary of Wasms.
* Opens explorer in a new window with the loaded binary of target wasm.

#### Why new window?
In case a huge wasm is passed, it lags up the window or maybe it will lead to a crash. So opening explorer in a new window is a better option (as suggested by mbx).