### PR TITLE
Move tab groups logic to store and actions

### DIFF
--- a/src/components/NewProjectDialog.tsx
+++ b/src/components/NewProjectDialog.tsx
@@ -28,10 +28,17 @@ import { File, FileType, Directory, extensionForFileType, nameForFileType, Proje
 import { KeyboardEvent, ChangeEvent, ChangeEventHandler } from "react";
 import { ListBox, ListItem, TextInputBox } from "./Widgets";
 
+export interface ProjectTemplate {
+  name: string;
+  directory?: string;
+  children: ProjectTemplate[];
+  openedFiles: [string[]];
+}
+
 export interface Template {
   name: string;
   description: string;
-  project: any;
+  project: ProjectTemplate;
   icon: string;
 }
 


### PR DESCRIPTION
App.tsx currently does a lot of things that it should not, moving tabs logic out of the component will help in better understanding of the code.

### Summary of Changes

* Change groups to tabGroups
* Move tabs out of App.tsx

### Test Plan

- [x] Open file from left file tree(Single and Double click)
- [x] Split pane
- [x] Close file in either pane
