### PR TITLE
Tidy up directory tree context menu a bit

### DIFF
--- a/src/components/DirectoryTree.tsx
+++ b/src/components/DirectoryTree.tsx
@@ -20,7 +20,7 @@
  */
 
 import * as React from "react";
-import { Project, File, Directory, FileType, getIconForFileType, ModelRef } from "../model";
+import { Project, File, Directory, FileType, getIconForFileType, ModelRef, isBinaryFileType } from "../model";
 import { Service } from "../service";
 import { GoDelete, GoPencil, GoGear, GoVerified, GoFileCode, GoQuote, GoFileBinary, GoFile, GoDesktopDownload } from "./shared/Icons";
 import { ITree, ContextMenuEvent, IDragAndDrop, DragMouseEvent, IDragAndDropData, IDragOverReaction, DragOverEffect, DragOverBubble } from "../monaco-extra";
@@ -122,6 +122,7 @@ export class DirectoryTree extends React.Component<DirectoryTreeProps, {
         const anchor = { x: event.posx + anchorOffset.x, y: event.posy + anchorOffset.y };
         const actions: any[] = [];
 
+        // Directory options
         if (file instanceof Directory) {
           actions.push(new (window as any).Action("x", "New File", "octicon-file-add", true, () => {
             return self.props.onNewFile && self.props.onNewFile(file as Directory);
@@ -132,37 +133,9 @@ export class DirectoryTree extends React.Component<DirectoryTreeProps, {
           actions.push(new (window as any).Action("x", "Upload File", "octicon-cloud-upload", true, () => {
              return self.props.onUploadFile && self.props.onUploadFile(file as Directory);
           }));
-        } else if (file.type === FileType.Wasm) {
-          actions.push(new (window as any).Action("x", "Optimize w/ Binaryen", "octicon-gear", true, () => {
-            Service.optimizeWasmWithBinaryen(file);
-          }));
-          actions.push(new (window as any).Action("x", "Validate w/ Binaryen", "octicon-check", true, () => {
-            Service.validateWasmWithBinaryen(file);
-          }));
-          actions.push(new (window as any).Action("x", "To asm.js w/ Binaryen", "octicon-file-code", true, () => {
-            Service.convertWasmToAsmWithBinaryen(file);
-          }));
-          actions.push(new (window as any).Action("x", "Download", "octicon-cloud-download", true, () => {
-            Service.download(file);
-          }));
-          actions.push(new (window as any).Action("x", "Disassemble w/ Wabt", "octicon-file-code", true, () => {
-            Service.disassembleWasmWithWabt(file);
-          }));
-          actions.push(new (window as any).Action("x", "Firefox x86", "octicon-file-binary", true, () => {
-            Service.disassembleX86(file);
-          }));
-          actions.push(new (window as any).Action("x", "Firefox x86 Baseline", "octicon-file-binary", true, () => {
-            Service.disassembleX86(file, "--wasm-always-baseline");
-          }));
-        } else if (file.type === FileType.C || file.type === FileType.Cpp) {
-          actions.push(new (window as any).Action("x", "Format w/ Clang", "octicon-quote", true, () => {
-            Service.clangFormat(file);
-          }));
-        } else if (file.type === FileType.Wast) {
-          actions.push(new (window as any).Action("x", "Assemble w/ Wabt", "octicon-file-binary", true, () => {
-            Service.assembleWastWithWabt(file);
-          }));
         }
+
+        // Common file options
         if (!(file instanceof Project)) {
           actions.push(new (window as any).Action("x", "Edit", "octicon-pencil", true, () => {
             return self.props.onEditFile && self.props.onEditFile(file as Directory);
@@ -170,10 +143,47 @@ export class DirectoryTree extends React.Component<DirectoryTreeProps, {
           actions.push(new (window as any).Action("x", "Delete", "octicon-x", true, () => {
             return self.props.onDeleteFile && self.props.onDeleteFile(file as Directory);
           }));
+          actions.push(new (window as any).Action("x", "Download", "octicon-cloud-download", true, () => {
+            Service.download(file);
+          }));
         }
-        actions.push(new (window as any).Action("x", "Gist", "octicon-gist", true, () => {
+
+        // Create a gist from everything but binary
+        if (!isBinaryFileType(file.type)) {
+          actions.push(new (window as any).Action("x", "Create Gist", "octicon-gist", true, () => {
             return self.props.onCreateGist && self.props.onCreateGist(file as Directory);
-        }));
+          }));
+        }
+
+        // File-type specific separated with a ruler
+        if (file.type === FileType.Wasm) {
+          actions.push(new (window as any).Action("x", "Validate", "octicon-check ruler", true, () => {
+            Service.validateWasmWithBinaryen(file);
+          }));
+          actions.push(new (window as any).Action("x", "Optimize", "octicon-gear", true, () => {
+            Service.optimizeWasmWithBinaryen(file);
+          }));
+          actions.push(new (window as any).Action("x", "Disassemble", "octicon-file-code", true, () => {
+            Service.disassembleWasmWithWabt(file);
+          }));
+          actions.push(new (window as any).Action("x", "To asm.js", "octicon-file-code", true, () => {
+            Service.convertWasmToAsmWithBinaryen(file);
+          }));
+          actions.push(new (window as any).Action("x", "To Firefox x86", "octicon-file-binary", true, () => {
+            Service.disassembleX86(file);
+          }));
+          actions.push(new (window as any).Action("x", "To Firefox x86 Baseline", "octicon-file-binary", true, () => {
+            Service.disassembleX86(file, "--wasm-always-baseline");
+          }));
+        } else if (file.type === FileType.C || file.type === FileType.Cpp) {
+          actions.push(new (window as any).Action("x", "Clang-Format", "octicon-quote ruler", true, () => {
+            Service.clangFormat(file);
+          }));
+        } else if (file.type === FileType.Wast) {
+          actions.push(new (window as any).Action("x", "Assemble", "octicon-file-binary ruler", true, () => {
+            Service.assembleWastWithWabt(file);
+          }));
+        }
         self.contextMenuService.showContextMenu({
           getAnchor: () => anchor,
 

--- a/src/service.ts
+++ b/src/service.ts
@@ -427,7 +427,7 @@ export class Service {
     }
     const data = file.getData() as ArrayBuffer;
     const module = Binaryen.readBinary(data);
-    alert(module.validate());
+    alert(module.validate() ? "Module is valid" : "Module is not valid");
   }
 
   static async validateWastWithBinaryen(file: File) {
@@ -469,8 +469,7 @@ export class Service {
       Service.downloadLink.style.display = "none";
       document.body.appendChild(Service.downloadLink);
     }
-    assert(file.type === FileType.Wasm);
-    const url = URL.createObjectURL(new Blob([file.getData()], { type: "application/wasm" }));
+    const url = URL.createObjectURL(new Blob([file.getData()], { type: "application/octet-stream" }));
     Service.downloadLink.href = url;
     Service.downloadLink.download = file.name;
     if (Service.downloadLink.href as any !== document.location) {

--- a/style/global.css
+++ b/style/global.css
@@ -842,6 +842,10 @@ a {
   font-weight: bold;
 }
 
+.action-label:focus {
+  color: inherit !important; /* first label is dark-blue otherwise? */
+}
+
 .monaco-icon-label.dirty::after {
   font-family: octicons;
   content: "\f052";
@@ -849,76 +853,75 @@ a {
 
 /* Menu Item Styles */
 
+.action-label.ruler {
+  border-top: 1px solid var(--grey-800);
+}
+
+.action-label::before {
+  padding-right: 8px;
+  width: 12px;
+  display: inline-block;
+  text-align: center;
+}
+
 .action-label.octicon-file-add::before {
   font-family: octicons;
   content: '\f05d';
-  padding-right: 8px;
 }
 
 .action-label.octicon-cloud-download::before {
   font-family: octicons;
   content: '\f00b';
-  padding-right: 8px;
 }
 
 .action-label.octicon-cloud-upload::before {
   font-family: octicons;
   content: '\f00c';
-  padding-right: 8px;
 }
 
 .action-label.octicon-pencil::before {
   font-family: octicons;
   content: '\f058';
-  padding-right: 8px;
 }
 
 .action-label.octicon-x::before {
   font-family: octicons;
   content: '\f081';
-  padding-right: 8px;
 }
 
 .action-label.octicon-quote::before {
   font-family: octicons;
   content: '\f063';
-  padding-right: 8px;
 }
 
 .action-label.octicon-gear::before {
   font-family: octicons;
   content: '\f02f';
-  padding-right: 8px;
 }
 
 .action-label.octicon-verified::before {
   font-family: octicons;
   content: '\f02f';
-  padding-right: 8px;
 }
 
 .action-label.octicon-file-code::before {
   font-family: octicons;
   content: '\f010';
-  padding-right: 8px;
 }
 
 .action-label.octicon-file-binary::before {
   font-family: octicons;
   content: '\f094';
-  padding-right: 8px;
 }
 
 .action-label.octicon-check::before {
   font-family: octicons;
   content: '\f03a';
-  padding-right: 8px;
 }
 
 .action-label.octicon-gist::before {
   font-family: octicons;
   content: '\f00e';
-  padding-right: 8px;
 }
 
 .label-name.error-dark::before {


### PR DESCRIPTION
![ctx](https://user-images.githubusercontent.com/1136893/36196888-661fb0c0-1172-11e8-8730-30518a0fd07f.jpg)

* Makes sure all icons display with the same width
* Orders by Directory options, Common file options, Gist if applicable, [ruler] File-specific options
* Fixes the first item showing as dark-blue (came from some focus rule in monaco)
* Can now download all kinds of files, not just .wasm
* Strips some not immediately useful detail texts