### PR TITLE
Fix top tabs missing background color after #89

### DIFF
--- a/style/global.css
+++ b/style/global.css
@@ -268,6 +268,7 @@ a {
   display: flex;
   width: 100%;
   height: 40px;
+  background: var(--grey-900);
 }
 .tabs-tab-container {
   display: flex;


### PR DESCRIPTION
Fix for #89 moving some things around in the CSS that are apparently still required for the top tabs background.

![screen](https://user-images.githubusercontent.com/1136893/36223776-b85f5d56-11c5-11e8-98c9-65c5cb4cfa6e.jpg)