### PR TITLE
Add transient file flag.

### DIFF
--- a/src/components/DirectoryTree.tsx
+++ b/src/components/DirectoryTree.tsx
@@ -86,6 +86,16 @@ export class FileTemplate {
     }
     this.label.innerHTML = file.name;
     this.monacoIconLabel.classList.toggle("dirty", file.isDirty);
+    this.monacoIconLabel.classList.toggle("transient", file.isTransient);
+    let title = "";
+    if (file.isDirty && file.isTransient) {
+      title =  "File has been modified and is transient.";
+    } else if (file.isDirty && !file.isTransient) {
+      title =  "File has been modified.";
+    } else if (!file.isDirty && file.isTransient) {
+      title =  "File is transient.";
+    }
+    this.monacoIconLabel.title = title;
   }
 }
 

--- a/src/service.ts
+++ b/src/service.ts
@@ -336,7 +336,7 @@ export class Service {
     function serialize(file: File) {
       if (file instanceof Directory) {
         if (file.name !== "out") {
-          file.mapEachFile((file: File) => serialize(file));
+          file.mapEachFile((file: File) => serialize(file), true);
         }
       } else {
         files[file.name] = {content: file.data};
@@ -352,10 +352,11 @@ export class Service {
 
   static async saveProject(project: Project, openedFiles: string[][], uri?: string): Promise<string> {
     function serialize(file: File): any {
+      assert(!file.isTransient);
       if (file instanceof Directory) {
         return {
           name: file.name,
-          children: file.mapEachFile((file: File) => serialize(file))
+          children: file.mapEachFile((file: File) => serialize(file), true)
         };
       } else {
         return {

--- a/style/global.css
+++ b/style/global.css
@@ -851,8 +851,18 @@ a {
 }
 
 .monaco-icon-label.dirty::after {
-  font-family: octicons;
-  content: "\f052";
+  content: "M";
+  font-size: 10px;
+}
+
+.monaco-icon-label.transient::after {
+  content: "T";
+  font-size: 10px;
+}
+
+.monaco-icon-label.dirty.transient::after {
+  content: "M T";
+  font-size: 10px;
 }
 
 /* Menu Item Styles */

--- a/templates/empty_c/build.ts
+++ b/templates/empty_c/build.ts
@@ -1,6 +1,6 @@
 gulp.task("build", async () => {
   const data = await Service.compileFile(project.getFile("src/main.c"), "c", "wasm", "-g -O3");
-  const outWasm = project.newFile("out/main.wasm", "wasm");
+  const outWasm = project.newFile("out/main.wasm", "wasm", true);
   outWasm.setData(data);
 });
 

--- a/templates/empty_rust/build.ts
+++ b/templates/empty_rust/build.ts
@@ -1,6 +1,6 @@
 gulp.task("build", async () => {
   const data = await Service.compileFile(project.getFile("src/main.rs"), "rust", "wasm", "-g -O3");
-  const outWasm = project.newFile("out/main.wasm", "wasm");
+  const outWasm = project.newFile("out/main.wasm", "wasm", true);
   outWasm.setData(data);
 });
 

--- a/templates/empty_ts/setup.js
+++ b/templates/empty_ts/setup.js
@@ -22,7 +22,7 @@ require(["assemblyscript/bin/asc"], asc => {
       writeFile: (filename, contents) => {
         const name = filename.startsWith("/") ? filename.substring(1) : filename;
         const type = filetypeForExtension(name.substring(name.lastIndexOf(".") + 1));
-        project.newFile(name, type).setData(contents);
+        project.newFile(name, type, true).setData(contents);
       },
       listFiles: (dirname) => []
     }, fn);

--- a/templates/hello_world_c/build.ts
+++ b/templates/hello_world_c/build.ts
@@ -1,6 +1,6 @@
 gulp.task("build", async () => {
   const data = await Service.compileFile(project.getFile("src/main.c"), "c", "wasm", "-g -O3");
-  const outWasm = project.newFile("out/main.wasm", "wasm");
+  const outWasm = project.newFile("out/main.wasm", "wasm", true);
   outWasm.setData(data);
 });
 


### PR DESCRIPTION
Files that are transient are temporary and are not saved and/or restored from projects. This is useful for generated `.wasm` binary files. ATM, there is no UI to toggle the flag, we should probably add that.

![image](https://user-images.githubusercontent.com/311082/36289260-ee6c308c-1273-11e8-8a81-f26dfe2b3ad9.png)

Transient have a T next to them. I've also changed the dirty files to have an M next to them.
