### PR TITLE
If statement for excluding  "out" from exportToGist not required

### DIFF
--- a/src/service.ts
+++ b/src/service.ts
@@ -335,9 +335,7 @@ export class Service {
     const files: any = {};
     function serialize(file: File) {
       if (file instanceof Directory) {
-        if (file.name !== "out") {
-          file.mapEachFile((file: File) => serialize(file), true);
-        }
+        file.mapEachFile((file: File) => serialize(file), true);
       } else {
         files[file.name] = {content: file.data};
       }


### PR DESCRIPTION
This is not required anymore because: [#97](https://github.com/wasdk/WebAssemblyStudio/pull/97)
### Summary of Changes

* Removed _if_ statement for checking if directory is _out_

#### Note:
I think, in case some user creates a new file inside "_out_" dir manually, then this will export it to gist.