### PR TITLE
Basic hover support for .wast files.

### DIFF
--- a/tests/__mocks__/monaco-editor.ts
+++ b/tests/__mocks__/monaco-editor.ts
@@ -36,6 +36,11 @@ class EditorModel {
   Range: function (l1, c1, l2, c2) {
     this.r = [l1, c1, l2, c2];
   },
+  languages: {
+    CompletionItemKind: {
+      Keyword: 12
+    }
+  }
 };
 
 class ContextViewService {
@@ -50,3 +55,5 @@ class ContextMenuService {
 }
 
 MonacoUtils.ContextMenuService = ContextMenuService;
+
+

--- a/tests/unit/wast.spec.ts
+++ b/tests/unit/wast.spec.ts
@@ -1,0 +1,23 @@
+/* Any copyright is dedicated to the Public Domain.
+ * http://creativecommons.org/publicdomain/zero/1.0/ */
+
+import { watWordAt, getWatCompletionItems } from "../../src/languages/wast";
+
+describe("AppActions component", () => {
+  it("output initially is empty", () => {
+    expect(watWordAt("(i32.add)", 0).word).toBeFalsy();
+    for (let i = 1; i < 8; i++) {
+      expect(watWordAt("(i32.add)", i).word).toBe("i32.add");
+    }
+    expect(watWordAt("(i32.add)", 8).word).toBeFalsy();
+    expect(watWordAt("((()()(())))", 2).word).toBeFalsy();
+    expect(watWordAt("abc def", 2).word).toBe("abc");
+    expect(watWordAt("ab def", 2).word).toBeFalsy();
+    expect(watWordAt("", 2).word).toBeFalsy();
+    expect(watWordAt("abcdef))", 2).word).toBe("abcdef");
+    expect(watWordAt("(i64.reinterpret/f64)", 2).word).toBe("i64.reinterpret/f64");
+    getWatCompletionItems().forEach(item => {
+      expect(watWordAt(`((${item.label}))`, 2).word).toBe(item.label);
+    });
+  });
+});


### PR DESCRIPTION
When hovering over a WebAssembly keyword a short description is displayed.
 
![image](https://user-images.githubusercontent.com/311082/36349705-4c9a0f6c-1440-11e8-8e6f-8c9b27c572ec.png)
