### PR TITLE
Support views

### DIFF
--- a/src/actions/AppActions.ts
+++ b/src/actions/AppActions.ts
@@ -23,6 +23,7 @@ import dispatcher from "../dispatcher";
 import { File, Directory, Project, filetypeForExtension } from "../model";
 import { App } from "../components/App";
 import { ProjectTemplate } from "../components/NewProjectDialog";
+import { View } from "../components/editor/View";
 import appStore from "../stores/AppStore";
 import { Service, Language } from "../service";
 import Group from "../utils/group";
@@ -44,6 +45,8 @@ export enum AppActionType {
   LOG_LN = "LOG_LN",
   SET_STATUS = "SET_STATUS",
   SANDBOX_RUN = "SANDBOX_RUN",
+  CLOSE_VIEW = "CLOSE_VIEW",
+  OPEN_VIEW = "OPEN_VIEW",
 }
 
 export interface AppAction {
@@ -134,6 +137,32 @@ export function splitGroup() {
   } as SplitGroupAction);
 }
 
+export interface OpenViewAction extends AppAction {
+  type: AppActionType.OPEN_VIEW;
+  view: View;
+  preview: boolean;
+}
+
+export function openView(view: View, preview = true) {
+  dispatcher.dispatch({
+    type: AppActionType.OPEN_VIEW,
+    view,
+    preview
+  } as OpenViewAction);
+}
+
+export interface CloseViewAction extends AppAction {
+  type: AppActionType.CLOSE_VIEW;
+  view: View;
+}
+
+export function closeView(view: View) {
+  dispatcher.dispatch({
+    type: AppActionType.CLOSE_VIEW,
+    view
+  } as CloseViewAction);
+}
+
 export interface OpenFileAction extends AppAction {
   type: AppActionType.OPEN_FILE;
   file: File;
@@ -147,18 +176,6 @@ export function openFile(file: File, preview = true) {
     file,
     preview
   } as OpenFileAction);
-}
-
-export interface CloseFileAction extends AppAction {
-  type: AppActionType.CLOSE_FILE;
-  file: File;
-}
-
-export function closeFile(file: File) {
-  dispatcher.dispatch({
-    type: AppActionType.CLOSE_FILE,
-    file
-  } as CloseFileAction);
 }
 
 export interface OpenProjectFilesAction extends AppAction {
@@ -188,7 +205,7 @@ export async function saveProject(fiddle: string) {
   const projectModel = appStore.getProject().getModel();
 
   const openedFiles = tabGroups.map((group) => {
-    return group.files.map((file) => file.getPath());
+    return group.views.map((view) => view.file.getPath());
   });
 
   await Service.saveProject(projectModel, openedFiles, fiddle);

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -27,6 +27,7 @@ import { Workspace } from "./Workspace";
 import { Editor, EditorPane, View, Tab, Tabs } from "./editor";
 import { Header } from "./Header";
 import { Toolbar } from "./Toolbar";
+import { ViewMode } from "./editor/View";
 import { build, run, runTask, editInWebAssemblyStudio } from "../actions/AppActions";
 
 import appStore from "../stores/AppStore";
@@ -39,7 +40,8 @@ import {
   splitGroup,
   openProjectFiles,
   openFile,
-  closeFile,
+  openView,
+  closeView,
   saveProject,
   focusTabGroup,
   logLn,
@@ -453,8 +455,8 @@ export class App extends React.Component<AppProps, AppState> {
       return groups.map(group => {
         // tslint:disable-next-line:jsx-key
         return <EditorPane
-          files={group.files.slice(0)}
-          file={group.file}
+          views={group.views.slice(0)}
+          view={group.currentView}
           preview={group.preview}
           onSplitEditor={() => splitGroup()}
           hasFocus={activeGroup === group}
@@ -462,19 +464,17 @@ export class App extends React.Component<AppProps, AppState> {
             // TODO: Should be taken care of in shouldComponentUpdate instead.
             focusTabGroup(group);
           }}
-          onClickFile={(file: File) => {
+          onClickView={(view: View) => {
             focusTabGroup(group);
-            openFile(file);
+            openView(view);
           }}
-          onDoubleClickFile={(file: File) => {
-            if (file instanceof Directory) {
-              return;
-            }
-            openFile(file, false);
-          }}
-          onClose={(file) => {
+          onDoubleClickView={(view: View) => {
             focusTabGroup(group);
-            closeFile(file);
+            openView(view, false);
+          }}
+          onClose={(view: View) => {
+            focusTabGroup(group);
+            closeView(view);
             }
           }
         />;

--- a/src/components/ControlCenter.tsx
+++ b/src/components/ControlCenter.tsx
@@ -51,7 +51,7 @@ export class ControlCenter extends React.Component<{}, {
       ]
     };
     const outputFile = appStore.getOutput().getModel();
-    this.outputView = new View(outputFile, null);
+    this.outputView = new View({ file: outputFile });
   }
   onOutputChanged = () => {
     this.updateOutputView();

--- a/src/components/Test.tsx
+++ b/src/components/Test.tsx
@@ -108,50 +108,50 @@ class TabBasicScrollTest extends React.Component<{
 
 class EditorPaneTest extends React.Component<{
 }, {
-    file: File,
-    files: File[]
+    view: View,
+    views: View[]
   }> {
   constructor(props: any) {
     super(props);
-    const a = new File("A", FileType.JavaScript);
-    const b = new File("B", FileType.JavaScript);
-    const c = new File("C", FileType.JavaScript);
+    const a = new View({ file: new File("A", FileType.JavaScript) });
+    const b = new View({ file: new File("B", FileType.JavaScript) });
+    const c = new View({ file: new File("C", FileType.JavaScript) });
 
-    a.onDidChangeData.register(() => this.forceUpdate());
-    b.onDidChangeData.register(() => this.forceUpdate());
-    c.onDidChangeData.register(() => this.forceUpdate());
+    a.file.onDidChangeData.register(() => this.forceUpdate());
+    b.file.onDidChangeData.register(() => this.forceUpdate());
+    c.file.onDidChangeData.register(() => this.forceUpdate());
 
     this.state = {
-      file: a,
-      files: [a, b, c]
+      view: a,
+      views: [a, b, c]
     };
   }
   render() {
     return <div style={{ height: 128 }}>
       <EditorPane
-        preview={this.state.file}
-        file={this.state.file}
-        files={this.state.files}
+        preview={this.state.view}
+        view={this.state.view}
+        views={this.state.views}
         onNewFile={
           () => {
-            const { files } = this.state;
-            const f = new File("X", FileType.JavaScript);
-            files.push(f);
+            const { views } = this.state;
+            const f = new View({ file: new File("X", FileType.JavaScript) });
+            views.push(f);
             // files.splice(i, 1);
-            this.setState({ files, file: files[files.length - 1] });
+            this.setState({ views, view: views[views.length - 1] });
           }
         }
-        onClickFile={
+        onClickView={
           (x) => {
-            this.setState({ file: x });
+            this.setState({ view: x });
           }
         }
         onClose={
           (x) => {
-            const { files } = this.state;
-            const i = files.indexOf(x);
-            files.splice(i, 1);
-            this.setState({ files, file: files[0] });
+            const { views } = this.state;
+            const i = views.indexOf(x);
+            views.splice(i, 1);
+            this.setState({ views, view: views[0] });
           }
         }
       />
@@ -177,7 +177,7 @@ export class Test extends React.Component<{
     layout();
   }
   render() {
-    const view = new View(new File("X", FileType.JavaScript), null);
+    const view = new View({ file: new File("X", FileType.JavaScript) });
     view.file.buffer.setValue(`
     render() {
       let { splits } = this.state;

--- a/src/components/editor/Editor.tsx
+++ b/src/components/editor/Editor.tsx
@@ -21,7 +21,8 @@
 
 import * as React from "react";
 import { Project, File, Directory, FileType, languageForFileType } from "../../model";
-import { View, EditorPane } from "./EditorPane";
+import { EditorPane } from "./EditorPane";
+import { View } from "./View";
 import { build, run } from "../../actions/AppActions";
 import "monaco-editor";
 

--- a/src/components/editor/View.tsx
+++ b/src/components/editor/View.tsx
@@ -19,7 +19,32 @@
  * SOFTWARE.
  */
 
-export { Editor } from "./Editor";
-export { EditorPane } from "./EditorPane";
-export { View } from "./View";
-export { Tab, Tabs } from "./Tabs";
+import { File } from "../../model";
+
+export enum ViewMode {
+  EDITOR,
+  PREVIEW,
+  READONLY
+}
+
+export interface ViewProps {
+  file: File;
+  mode?: ViewMode;
+  onClose?: Function;
+  preview?: boolean;
+}
+
+export class View {
+  public file: File;
+  public mode: ViewMode;
+  public onClose?: Function;
+  public state: monaco.editor.ICodeEditorViewState;
+  public preview: boolean;
+
+  constructor({ file, mode, onClose, preview }: ViewProps) {
+    this.file = file;
+    this.mode = mode || ViewMode.EDITOR;
+    this.preview = preview;
+    this.onClose = onClose;
+  }
+}

--- a/tests/utils/group.spec.tsx
+++ b/tests/utils/group.spec.tsx
@@ -1,0 +1,51 @@
+import Group from "../../src/utils/group";
+import { View } from "../../src/components/editor/View";
+import { File, FileType } from "../../src/model";
+
+function generateFiles() {
+    return {
+        a: new File("A", FileType.JavaScript),
+        b: new File("B", FileType.JavaScript),
+        c: new File("C", FileType.JavaScript)
+    };
+}
+
+describe("Tab Group tests", () => {
+    it("should open a file", () => {
+        const files = generateFiles();
+        const a = new View({ file: files.a });
+        const b = new View({ file: files.b });
+        const group = new Group(a, [a, b]);
+
+        group.openFile(files.c);
+
+        expect(group.currentView.file.name).toBe("C");
+        expect(group.preview.file.name).toBe("C");
+    });
+    it("should switch between views", () => {
+        const files = generateFiles();
+        const a = new View({ file: files.a });
+        const b = new View({ file: files.b });
+        const group = new Group(a, [a, b]);
+
+        group.openFile(files.c);
+        expect(group.currentView.file.name).toBe("C");
+
+        group.open(a);
+
+        expect(group.currentView.file.name).toBe("A");
+        expect(group.preview.file.name).toBe("C");
+    });
+    it("should close a view", () => {
+        const files = generateFiles();
+        const a = new View({ file: files.a });
+        const b = new View({ file: files.b });
+        const group = new Group(a, [a, b]);
+
+        group.openFile(files.c);
+        group.close(group.preview);
+
+        expect(group.currentView.file.name).toBe("B");
+        expect(group.preview).toBe(null);
+    });
+});


### PR DESCRIPTION
Associated Issue: #17

This is a subset of the main PR of supporting markdown.
This presents another abstraction layer above file, to handle the display related activities and this was also needed so that we can edit a file in two editor instances without having to copy it, and in previewing the file as well.

### Summary of Changes

* Migrate from `file` to `view`
* `EDIT` : Improved the split group logic, the new editor pane now comes right next to current pane cloning the currently active file, previously, it just took the last pane and duplicated it.
