### PR TITLE
Add Empty Wat template

### DIFF
--- a/lib/fiddle.d.ts
+++ b/lib/fiddle.d.ts
@@ -33,6 +33,7 @@ declare class Service {
    * Disassembles WebAssembly binary into Wat format using Wabt.
    */
   static disassembleWasm(buffer: ArrayBuffer): Promise<string>;
+  static assembleWat(wat: string): Promise<ArrayBuffer>;
 }
 declare const project: any;
 

--- a/templates/empty_wat/README.md
+++ b/templates/empty_wat/README.md
@@ -1,0 +1,1 @@
+# Empty Wat Project

--- a/templates/empty_wat/build.ts
+++ b/templates/empty_wat/build.ts
@@ -1,0 +1,7 @@
+gulp.task("build", async () => {
+  const data = await Service.assembleWat(project.getFile("src/main.wat").getData());
+  const outWasm = project.newFile("out/main.wasm", "wasm", true);
+  outWasm.setData(data);
+});
+
+gulp.task("default", ["build"], async () => {});

--- a/templates/empty_wat/src/main.html
+++ b/templates/empty_wat/src/main.html
@@ -1,0 +1,13 @@
+<html>
+
+<body>
+  <style>
+    body {
+      background-color: rgb(255, 255, 255);
+    }
+  </style>
+  <script src="src/main.js"></script>
+  <span id="container" />
+</body>
+
+</html>

--- a/templates/empty_wat/src/main.js
+++ b/templates/empty_wat/src/main.js
@@ -1,0 +1,6 @@
+fetch(getFileURL('out/main.wasm')).then(response =>
+  response.arrayBuffer()
+).then(bytes => WebAssembly.instantiate(bytes)).then(results => {
+  instance = results.instance;
+  document.getElementById("container").innerText = instance.exports.add(1,1);
+});

--- a/templates/empty_wat/src/main.wat
+++ b/templates/empty_wat/src/main.wat
@@ -1,0 +1,7 @@
+(module
+  (func $add (param $lhs i32) (param $rhs i32) (result i32)
+    get_local $lhs
+    get_local $rhs
+    i32.add)
+  (export "add" (func $add))
+)

--- a/templates/templates.js
+++ b/templates/templates.js
@@ -99,4 +99,35 @@ See the [AssemblyScript wiki](https://github.com/AssemblyScript/assemblyscript/w
       ["README.md"]
     ]
   }
+}, {
+  "name": "Empty Wat Project",
+  "description": `# Empty Wat Project
+`,
+  "icon": "",
+  "project": {
+    "name": "Project",
+    "directory": "empty_wat",
+    "children": [{
+      "name": "src",
+      "children": [{
+        "name": "main.wat",
+        "type": "wat"
+      }, {
+        "name": "main.js",
+        "type": "javascript",
+      }, {
+        "name": "main.html",
+        "type": "html",
+      }]
+    }, {
+      "name": "build.ts",
+      "type": "typescript",
+    }, {
+      "name": "README.md",
+      "type": "markdown",
+    }],
+    "openedFiles": [
+      ["README.md"]
+    ]
+  }
 }]


### PR DESCRIPTION
Associated Issue: #32 

### Summary of Changes

* Add Empty Wat template
* Add assembleWat to editor definitions (in `fiddle.d.ts`)
* Add new template to `templates.js`. This needs a Wat icon.

### Test Plan
- [x] Create "Empty Wat" project
- [x] Check that `main.wat` has function `add`
- [x] Check that `main.js` calls `add(1,1)`
- [x] Click Build button, and confirm that `main.wasm` is produced  
- [x] Click Run button, and observe that Result panel shows result `2`
- [x] Check `build.ts` to make sure that `assembleWat` is not flagged as an error
