### PR TITLE
Intercept 'fetch' at the sandbox level

### DIFF
--- a/src/components/Sandbox.tsx
+++ b/src/components/Sandbox.tsx
@@ -87,6 +87,23 @@ export class Sandbox extends React.Component<{}, {}>  {
       logger.logLn(Array.prototype.join.call(arguments), "error");
       error.apply(contentWindow.console, arguments);
     })(contentWindow.console.error);
+    // Hijack fetch
+    contentWindow.fetch = (input: string, init?: RequestInit) => {
+      const url = new URL(input, "http://example.org/src/main.html");
+      const file = project.getFile(url.pathname.substr(1));
+      if (file) {
+        return Promise.resolve(
+          new Response(file.getData(), {
+            status: 200,
+            statusText: "OK",
+            headers: {
+              "Content-Type": mimeTypeForFileType(file.type)
+            }
+          })
+        );
+      }
+      return fetch(input, init);
+    };
     contentWindow.getFileURL = (path: string) => {
       const file = project.getFile(path);
       if (!file) {

--- a/templates/empty_c/src/main.js
+++ b/templates/empty_c/src/main.js
@@ -1,4 +1,4 @@
-fetch(getFileURL('out/main.wasm')).then(response =>
+fetch('../out/main.wasm').then(response =>
   response.arrayBuffer()
 ).then(bytes => WebAssembly.instantiate(bytes)).then(results => {
   instance = results.instance;

--- a/templates/empty_rust/src/main.js
+++ b/templates/empty_rust/src/main.js
@@ -1,4 +1,4 @@
-fetch(getFileURL('out/main.wasm')).then(response =>
+fetch('../out/main.wasm').then(response =>
   response.arrayBuffer()
 ).then(bytes => WebAssembly.instantiate(bytes)).then(results => {
   instance = results.instance;

--- a/templates/empty_ts/src/main.js
+++ b/templates/empty_ts/src/main.js
@@ -1,4 +1,4 @@
-WebAssembly.instantiateStreaming(fetch(getFileURL("out/main.wasm")), {
+WebAssembly.instantiateStreaming(fetch("../out/main.wasm"), {
   env: {
     sayHello: function() {
       console.log("Hello from WebAssembly!");

--- a/templates/empty_wat/src/main.js
+++ b/templates/empty_wat/src/main.js
@@ -1,4 +1,4 @@
-fetch(getFileURL('out/main.wasm')).then(response =>
+fetch('../out/main.wasm').then(response =>
   response.arrayBuffer()
 ).then(bytes => WebAssembly.instantiate(bytes)).then(results => {
   instance = results.instance;

--- a/templates/hello_world_c/src/main.js
+++ b/templates/hello_world_c/src/main.js
@@ -1,4 +1,4 @@
-let x = getFileURL('out/main.wasm');
+let x = '../out/main.wasm';
 
 let instance = null;
 let memoryStates = new WeakMap();
@@ -60,5 +60,5 @@ fetch(x).then(response =>
   ).then(results => {
     instance = results.instance;
     document.getElementById("container").innerText = instance.exports.main();
-    
+
   });


### PR DESCRIPTION
Associated Issue: #112

### Summary of Changes

* Replaces 'fetch' in the sandbox with a wrapper that checks for project files first and otherwise falls back to normal fetch

### Test Plan

Create a new C/Rust/AssemblyScript/Wat project, build and run.