### PR TITLE
Update AssemblyScript project's package.json

### DIFF
--- a/templates/empty_ts/package.json
+++ b/templates/empty_ts/package.json
@@ -1,13 +1,12 @@
 {
-    "name": "@wasm/empty_ts",
-    "description": "",
-    "version": "1.0.0",
-    "scripts": {
-        "build": "gulp"
-    },
-    "devDependencies": {
-        "@wasm/studio-utils": "*",
-        "gulp": "~3.9.1",
-        "typescript": "~2.7.2"
-    }
+  "name": "@wasm/empty_ts",
+  "description": "",
+  "version": "1.0.0",
+  "scripts": {
+    "build": "gulp"
+  },
+  "devDependencies": {
+    "assemblyscript": "AssemblyScript/assemblyscript",
+    "gulp": "^3.9.1"
+  }
 }


### PR DESCRIPTION
The only *offline* dependencies ultimately required here are gulp and asc. *Online*, it's pretty much using `project:load` to polyfill the compiler when running in WebAssembly Studio, but this one isn't called in an *offline* environment.