### PR TITLE
Fix infinite loop caused by dragging and dropping a folder over itself.

### DIFF
--- a/src/components/DirectoryTree.tsx
+++ b/src/components/DirectoryTree.tsx
@@ -259,7 +259,7 @@ export class DirectoryTree extends React.Component<DirectoryTreeProps, {
       onDragOver(tree: ITree, data: IDragAndDropData, targetElement: File, originalEvent: DragMouseEvent): IDragOverReaction {
         const file: File = (data.getData() as any)[0];
         return {
-          accept: targetElement instanceof Directory,
+          accept: targetElement instanceof Directory && targetElement !== file && !targetElement.isDescendantOf(file),
           bubble: DragOverBubble.BUBBLE_DOWN,
           autoExpand: true
         };

--- a/src/model.ts
+++ b/src/model.ts
@@ -468,6 +468,16 @@ export class File {
   toString() {
     return "File [" + this.name + "]";
   }
+  isDescendantOf(element: File): boolean {
+    let parent = this.parent;
+    while (parent) {
+      if (parent === element) {
+        return true;
+      }
+      parent = parent.parent;
+    }
+    return false;
+  }
 }
 
 export class Directory extends File {

--- a/tests/unit/descendant.spec.ts
+++ b/tests/unit/descendant.spec.ts
@@ -1,0 +1,30 @@
+/* Any copyright is dedicated to the Public Domain.
+ * http://creativecommons.org/publicdomain/zero/1.0/ */
+
+import { Directory } from "../../src/model";
+
+function getDirectoryStructure() {
+  const a = new Directory("test");
+  const b = a.newDirectory("b");
+  const c = b.newDirectory("c");
+  return { a, b, c };
+}
+
+describe("File.isDescendantOf tests", () => {
+  it("should return true if file is direct child of given element", () => {
+    const { a, b } = getDirectoryStructure();
+    expect(b.isDescendantOf(a)).toBe(true);
+  });
+  it("should return true if file is nested child of given element", () => {
+    const { a, c } = getDirectoryStructure();
+    expect(c.isDescendantOf(a)).toBe(true);
+  });
+  it("should return false if file is not a descendant of given element", () => {
+    const { a, b } = getDirectoryStructure();
+    expect(a.isDescendantOf(b)).toBe(false);
+  });
+  it("should return false if called with itself as argument", () => {
+    const { a } = getDirectoryStructure();
+    expect(a.isDescendantOf(a)).toBe(false);
+  });
+});


### PR DESCRIPTION
Associated Issue: #137

### Summary of Changes
* Adding if statement in onMoveFile (src/components/App.tsx) that returns early if the file being moved is actually a folder being moved into itself.

### Test Plan
- [x] Create an Empty C Project.
- [x] Drag the src folder and drop it over itself.
- [x] Infinite loop no longer fires
