### PR TITLE
Add parameter to open a template, just like a fiddle

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -65,6 +65,7 @@ const parameters = getUrlParameters();
 const embed = parameters["embed"] === true ? true : !!parseInt(parameters["embed"], 10);
 const update = parameters["update"] === true ? true : !!parseInt(parameters["update"], 10);
 const fiddle = parameters["fiddle"] || parameters["f"];
+const template = parameters["template"] || parameters["t"];
 
 (window["require"])(["vs/editor/editor.main", "require"], (_: any, require: any) => {
   MonacoUtils.initialize(require);
@@ -75,7 +76,7 @@ const fiddle = parameters["fiddle"] || parameters["f"];
     );
   } else {
     ReactDOM.render(
-      <App embed={embed} update={update} fiddle={fiddle}/>,
+      <App embed={embed} update={update} fiddle={fiddle} template={template}/>,
       document.getElementById("app")
     );
   }


### PR DESCRIPTION
### Summary of Changes

* Added a parameter `template=` / `t=` (like `fiddle=`/ `f=`) that opens a template, either by its full name or template directory.
* Now also opens the "New Project Dialog" if a fiddle or template does not exist.

### Test Plan

* Open WebAssembly Studio with `?t=hello_world_c`, `?template=Hello World in C` etc.