### PR TITLE
Implement Upload Files and Directories.

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -574,8 +574,9 @@ export class App extends React.Component<AppProps, AppState> {
           directory={this.state.uploadFileDialogDirectory}
           onCancel={() => {
             this.setState({ uploadFileDialogDirectory: null });
-           }}
+          }}
           onUpload={(files: File[]) => {
+            // TODO: Handle file collisions.
             files.map((file: File) => {
               addFileTo(file, this.state.uploadFileDialogDirectory.getModel());
             });

--- a/src/components/Widgets.tsx
+++ b/src/components/Widgets.tsx
@@ -74,21 +74,32 @@ export class TextInputBox extends React.Component<{
   }
 }
 
-export class FileUploadInput extends React.Component<{
-  label: string;
+export class UploadInput extends React.Component<{
   onChange?: ChangeEventHandler<any>;
 }, {
 
 }> {
-  inputElement: any;
+  inputElement: HTMLInputElement;
+  setInputElement(ref: HTMLInputElement) {
+    this.inputElement = ref;
+  }
   constructor(props: any) {
     super(props);
   }
-  open() {
+  open(upload: "files" | "directory") {
+    if (this.inputElement && upload === "directory") {
+      this.inputElement.setAttribute("directory", "true");
+      this.inputElement.setAttribute("webkitdirectory", "true");
+      this.inputElement.setAttribute("allowdirs", "true");
+    } else {
+      this.inputElement.removeAttribute("directory");
+      this.inputElement.removeAttribute("webkitdirectory");
+      this.inputElement.removeAttribute("allowdirs");
+    }
     this.inputElement.click();
   }
   render() {
-    return <input id="file-upload-input"  ref={input => this.inputElement = input} type="file" onChange={this.props.onChange} multiple hidden/>;
+    return <input id="file-upload-input" ref={ref => this.setInputElement(ref)} type="file" onChange={this.props.onChange} multiple hidden/>;
   }
 }
 

--- a/src/components/shared/Icons.tsx
+++ b/src/components/shared/Icons.tsx
@@ -102,6 +102,12 @@ export class GoFileCode extends React.PureComponent {
   }
 }
 
+export class GoFileDirectory extends React.PureComponent {
+  render() {
+    return <svg className="octicon octicon-file-directory" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M13 4H7V3c0-.66-.31-1-1-1H1c-.55 0-1 .45-1 1v10c0 .55.45 1 1 1h12c.55 0 1-.45 1-1V5c0-.55-.45-1-1-1zM6 4H1V3h5v1z"/></svg>;
+  }
+}
+
 export class GoQuote extends React.PureComponent {
   render() {
     return <svg className="octicon octicon-quote" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fillRule="evenodd" d="M6.16 3.5C3.73 5.06 2.55 6.67 2.55 9.36c.16-.05.3-.05.44-.05 1.27 0 2.5.86 2.5 2.41 0 1.61-1.03 2.61-2.5 2.61-1.9 0-2.99-1.52-2.99-4.25 0-3.8 1.75-6.53 5.02-8.42L6.16 3.5zm7 0c-2.43 1.56-3.61 3.17-3.61 5.86.16-.05.3-.05.44-.05 1.27 0 2.5.86 2.5 2.41 0 1.61-1.03 2.61-2.5 2.61-1.89 0-2.98-1.52-2.98-4.25 0-3.8 1.75-6.53 5.02-8.42l1.14 1.84h-.01z"/></svg>;
@@ -171,5 +177,11 @@ export class GoEye extends React.PureComponent {
 export class GoCode extends React.PureComponent {
   render() {
     return <svg className="octicon octicon-code" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M9.5 3L8 4.5 11.5 8 8 11.5 9.5 13 14 8 9.5 3zm-5 0L0 8l4.5 5L6 11.5 2.5 8 6 4.5 4.5 3z"/></svg>;
+  }
+}
+
+export class GoCloudUpload extends React.PureComponent {
+  render() {
+    return <svg className="octicon octicon-cloud-upload" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7 9H5l3-3 3 3H9v5H7V9zm5-4c0-.44-.91-3-4.5-3C5.08 2 3 3.92 3 6 1.02 6 0 7.52 0 9c0 1.53 1 3 3 3h3v-1.3H3c-1.62 0-1.7-1.42-1.7-1.7 0-.17.05-1.7 1.7-1.7h1.3V6c0-1.39 1.56-2.7 3.2-2.7 2.55 0 3.13 1.55 3.2 1.8v1.2H12c.81 0 2.7.22 2.7 2.2 0 2.09-2.25 2.2-2.7 2.2h-2V12h2c2.08 0 4-1.16 4-3.5C16 6.06 14.08 5 12 5z"/></svg>;
   }
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/311082/36938710-7b2407f8-1eda-11e8-91df-d542e9e46f84.png)

The upload file / directory dialog now lets you select directories and upload them. Optionally, you can upload the contents of the root directory if there is one. This makes it possible to select template directories and replicate the project structure in wasm studio easily.