### PR TITLE
Fix opened tabs of deleted files

### DIFF
--- a/src/actions/AppActions.ts
+++ b/src/actions/AppActions.ts
@@ -47,6 +47,7 @@ export enum AppActionType {
   POP_STATUS = "POP_STATUS",
   SANDBOX_RUN = "SANDBOX_RUN",
   CLOSE_VIEW = "CLOSE_VIEW",
+  CLOSE_TABS = "CLOSE_TABS",
   OPEN_VIEW = "OPEN_VIEW",
 }
 
@@ -162,6 +163,18 @@ export function closeView(view: View) {
     type: AppActionType.CLOSE_VIEW,
     view
   } as CloseViewAction);
+}
+
+export interface CloseTabsAction extends AppAction {
+  type: AppActionType.CLOSE_TABS;
+  file: File;
+}
+
+export function closeTabs(file: File) {
+  dispatcher.dispatch({
+    type: AppActionType.CLOSE_TABS,
+    file
+  } as CloseTabsAction);
 }
 
 export interface OpenFileAction extends AppAction {

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -42,6 +42,7 @@ import {
   openFile,
   openView,
   closeView,
+  closeTabs,
   saveProject,
   focusTabGroup,
   setViewType,
@@ -624,6 +625,7 @@ export class App extends React.Component<AppProps, AppState> {
                 message = `Are you sure you want to delete '${file.name}'?`;
               }
               if (confirm(message)) {
+                closeTabs(file);
                 deleteFile(file);
               }
             }}


### PR DESCRIPTION
Associated Issue: #66 

### Summary of Changes

* Created an Action that specifically evaluates every view of every group looking for the ones that contains the file that was deleted by the user. The action *closeTabs* is invoked along *deleteFile*.
* A private method on AppStore was created. Is a refactored version of a piece of code that *closeView* originally had. Now *closeView* and *closeTabs* invoke *closeGroup* when a group needs to be closed and also handles the next appropriate tab to focus.

### Test Plan

It was tested by opening the same file two or three times by splitting the editor. Then, the file was deleted and all the tabs related to that file were closed.