### PR TITLE
Fixed pinning issue

### DIFF
--- a/src/utils/group.ts
+++ b/src/utils/group.ts
@@ -39,7 +39,7 @@ export default class Group {
     if (index >= 0) {
       // Switch to the view if it's already open.
       this.currentView = view;
-      if (!shouldPreview) {
+      if (!shouldPreview && this.preview === view) {
         this.preview = null;
       }
       return;


### PR DESCRIPTION
Associated Issue: #57

### Summary of Changes

When a user double clicks a tab other than the current preview tab, the preview tab is no longer incorrectly pinned.

### Test Plan

Made changes to the group.ts file
Confirmed results on a local dev server
ran `npm run test` and passed all tests
