### PR TITLE
Make modifier indicator consistent with tab representation

### DIFF
--- a/src/components/DirectoryTree.tsx
+++ b/src/components/DirectoryTree.tsx
@@ -47,6 +47,8 @@ export class FileTemplate {
   readonly label: HTMLAnchorElement;
   readonly description: HTMLSpanElement;
   readonly monacoIconLabel: HTMLDivElement;
+  readonly labelIconDirty: HTMLDivElement;
+  readonly labelIconTransient: HTMLDivElement;
   constructor(container: HTMLElement) {
     this.monacoIconLabel = document.createElement("div");
     this.monacoIconLabel.className = "monaco-icon-label";
@@ -64,6 +66,14 @@ export class FileTemplate {
     this.description = document.createElement("span");
     this.description.className = "label-description";
     labelDescriptionContainer.appendChild(this.description);
+
+    this.labelIconTransient = document.createElement("div");
+    this.labelIconTransient.className = "label-icon";
+    this.monacoIconLabel.appendChild(this.labelIconTransient);
+
+    this.labelIconDirty = document.createElement("div");
+    this.labelIconDirty.className = "label-icon";
+    this.monacoIconLabel.appendChild(this.labelIconDirty);
   }
   dispose() {
     // TODO dispose resources?
@@ -90,8 +100,8 @@ export class FileTemplate {
       this.monacoIconLabel.classList.add(icon);
     }
     this.label.innerHTML = file.name;
-    this.monacoIconLabel.classList.toggle("dirty", file.isDirty);
-    this.monacoIconLabel.classList.toggle("transient", file.isTransient);
+    this.labelIconDirty.classList.toggle("dirty", file.isDirty);
+    this.labelIconTransient.classList.toggle("transient", file.isTransient);
     let title = "";
     if (file.isDirty && file.isTransient) {
       title =  "File has been modified and is transient.";

--- a/style/global.css
+++ b/style/global.css
@@ -860,19 +860,28 @@ a {
   color: inherit !important; /* first label is dark-blue otherwise? */
 }
 
-.monaco-icon-label.dirty::after {
-  content: "M";
-  font-size: 10px;
+.monaco-icon-label > .label-icon {
+  opacity: 0.75;
+  font-size: 90%;
+  font-weight: 600;
+  padding: 0px;
+  text-align: center;
+  margin-left: auto;
 }
 
-.monaco-icon-label.transient::after {
+.monaco-icon-label > .label-icon ~ .label-icon {
+  margin-left: inherit;
+  padding: 0 12px 0 5px;
+}
+
+.monaco-icon-label > .label-icon.dirty {
+  background: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' height='16' width='16'%3E%3Ccircle fill='%23C5C5C5' cx='8' cy='8' r='4'/%3E%3C/svg%3E") 50% no-repeat;
+}
+
+.monaco-icon-label > .label-icon.transient::after {
   content: "T";
   font-size: 10px;
-}
-
-.monaco-icon-label.dirty.transient::after {
-  content: "M T";
-  font-size: 10px;
+  float: right;
 }
 
 /* Menu Item Styles */


### PR DESCRIPTION
Associated Issue: #158

Here's the contributing guide at https://github.com/wasdk/WebAssemblyStudio/wiki/Contributing

### Summary of Changes

* Make modifier indicator consistent with tab representation

### Test Plan

I have tested by using it on two browsers Firefox and chrome.

Example test plan:

- [x] Create C "hello, world" project
- [x] Click Build button 
- [x] Click Run button, and observe the Result pannel
- [x] Clicking the "x" on the Result panel closes it

### Screenshots/Videos (OPTIONAL)
1. Modiefied but not in transient mode
![screenshot_20180318_111813](https://user-images.githubusercontent.com/5251472/37563059-48865c0e-2a9e-11e8-8e94-dae56a8a9089.png)
2. Modified with transient mode
![screenshot_20180318_111829](https://user-images.githubusercontent.com/5251472/37563060-498cdc04-2a9e-11e8-9eb2-8660a206e517.png)
3. Transient without modified mode
![screenshot_20180318_111840](https://user-images.githubusercontent.com/5251472/37563061-4a7c656c-2a9e-11e8-8d93-381ae178ce9e.png)
