### PR TITLE
Fix silent overwrite behaviour when moving file/folder

### DIFF
--- a/src/components/DirectoryTree.tsx
+++ b/src/components/DirectoryTree.tsx
@@ -270,7 +270,10 @@ export class DirectoryTree extends React.Component<DirectoryTreeProps, {
       onDragOver(tree: ITree, data: IDragAndDropData, targetElement: File, originalEvent: DragMouseEvent): IDragOverReaction {
         const file: File = (data.getData() as any)[0];
         return {
-          accept: targetElement instanceof Directory && targetElement !== file && !targetElement.isDescendantOf(file),
+          accept: targetElement instanceof Directory &&
+                  targetElement !== file &&
+                  !targetElement.isDescendantOf(file) &&
+                  !targetElement.getImmediateChild(file.name),
           bubble: DragOverBubble.BUBBLE_DOWN,
           autoExpand: true
         };


### PR DESCRIPTION
Currently, when moving a file/folder into a folder already containing a file/folder (immediate child) by that name - the moved content is silently deleted which may lead to the user loosing work. This PR fixes this behavior.

### Summary of Changes
* Adding additional check in onDragOver (DirectoryTree.tsx) making the accept property return false if targetElement already contains immediate child with same name as file/folder being moved

### Test Plan
- Create empty C project
- Create new folder /test and /test/src
- Create new file at root called main.c
- Try moving /main.c -> /src (Should no longer be accepted)
- Try moving /src -> /test (Should no longer be accepted)
