### PR TITLE
Fix all-content-selection when opening or switching tabs

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -495,6 +495,10 @@ export class App extends React.Component<AppProps, AppState> {
           }}
           onChangeViewType={(view, type) => setViewType(view, type)}
           onClickView={(view: View) => {
+            if (!(appStore.getActiveTabGroup().currentView === view)) {
+              // Avoids the propagation of content selection between tabs.
+              window.getSelection().removeAllRanges();
+            }
             focusTabGroup(group);
             openView(view);
           }}
@@ -636,6 +640,8 @@ export class App extends React.Component<AppProps, AppState> {
               }
             }}
             onClickFile={(file: File) => {
+              // Avoids the propagation of content selection between tabs.
+              window.getSelection().removeAllRanges();
               openFile(file, defaultViewTypeForFileType(file.type));
             }}
             onDoubleClickFile={(file: File) => {

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -52,7 +52,7 @@ import { Project, File, FileType, Directory, shallowCompare, ModelRef, fileTypeF
 import { Service, Language } from "../service";
 import { Split, SplitOrientation, SplitInfo } from "./Split";
 
-import { layout, assert } from "../util";
+import { layout, assert, resetDOMSelection } from "../util";
 import registerLanguages from "../utils/registerLanguages";
 
 import * as Mousetrap from "mousetrap";
@@ -497,7 +497,7 @@ export class App extends React.Component<AppProps, AppState> {
           onClickView={(view: View) => {
             if (!(appStore.getActiveTabGroup().currentView === view)) {
               // Avoids the propagation of content selection between tabs.
-              window.getSelection().removeAllRanges();
+              resetDOMSelection();
             }
             focusTabGroup(group);
             openView(view);
@@ -641,7 +641,7 @@ export class App extends React.Component<AppProps, AppState> {
             }}
             onClickFile={(file: File) => {
               // Avoids the propagation of content selection between tabs.
-              window.getSelection().removeAllRanges();
+              resetDOMSelection();
               openFile(file, defaultViewTypeForFileType(file.type));
             }}
             onDoubleClickFile={(file: File) => {

--- a/src/util.ts
+++ b/src/util.ts
@@ -189,6 +189,10 @@ export function layout() {
   }, layoutThrottleDuration);
 }
 
+export function resetDOMSelection() {
+  window.getSelection().removeAllRanges();
+}
+
 export function assert(c: any, message?: string) {
   if (!c) {
     throw new Error(message);


### PR DESCRIPTION
Associated Issue: #99 

### Summary of Changes

* Remove the browser content selection when a different tab than the current one is clicked.
* Remove the browser content selection when a tab is opened by clicking a file.

This two changes avoids the propagation of the browser content selection when navigating tabs and it doesn't affect the text selection that the Monaco editor does on the code.

### Test Plan

## Chrome:
Although the plan to reproduce it on chrome is explained in the issue, I couldn't do it exactly in that way. However, the strange behavior of all-content-selection can be reproduced by selecting the content of a markdown document on preview mode by clicking three times on it, and then, changing to the other tabs to observe how all the content-selection is propagated to them.

## Mozilla:
This was reproduced similar as it is explained on the issue, although it required me to click two times on an empty space, and then open a file to observe how is all selected.

With the patch, neither of this two cases occur.

Example test plan:

- [x] Create a new project with a default template.
- [x] Check that the bug is solved by trying to reproduce it with the steps mentioned above and in the issue referenced.