### PR TITLE
Added coverage command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 dist
 node_modules
 src/components/Test*.tsx
+coverage

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "dev-server": "npm run templates && webpack-dev-server",
     "test": "webpack --mode production && node bin/check-bundle-size.js && npm run jest && npm run tslint",
     "jest": "jest",
+    "coverage": "jest --coverage",
     "clean": "rm -r dist/*",
     "tslint": "tslint -p .",
     "templates": "node bin/bundle-templates.js > dist/templates.js"
@@ -28,6 +29,9 @@
     },
     "testMatch": [
       "**/tests/**/**/**.spec.(ts|tsx|js)"
+    ],
+    "collectCoverageFrom": [
+      "src/**/**.(ts|tsx|js)"
     ]
   },
   "repository": {


### PR DESCRIPTION
Added coverage command which makes it a little bit more convenient to measure coverage when writing tests.

**Instead of having to**:
```bash
npm run jest -- --coverage
# => coverage report for files that were executed during the test run
# .. then manually ignore /coverage folder
``` 

**Simply run**:
```bash
npm run coverage
# => coverage report for all files in /src (ts|tsx|js)
``` 
### Thoughts
- This promotes measuring coverage when adding new tests by being visible in package.json
- Some info about this could be added to the Wiki under Testing/Contributing
- This includes coverage for all files in /src to give you the whole picture

### Summary of Changes
* Added coverage script to package.json
* Added collectCoverageFrom option to jest config in package.json
* Ignoring coverage directory in .gitignore

### Test Plan
- Running `npm run coverage` now generates a coverage report for all files in /src
- Generated coverage folder is now ignored by git
