### PR TITLE
C-Template: Create function prototype for main()

### DIFF
--- a/templates/hello_world_c/src/main.c
+++ b/templates/hello_world_c/src/main.c
@@ -4,7 +4,7 @@
 #define WASM_EXPORT __attribute__((visibility("default")))
 
 WASM_EXPORT
-int main() {
+int main(void) {
   printf("Hello World\n");
 }
 


### PR DESCRIPTION
Associated Issue: N//A

### Summary of Changes

* An empty parameter-list in a function declarator does not specify the parameters, except when part of a function definition, however in either case it does not create a function prototype, which allows for calling `main()` with more than zero arguments. This is a primarily stylistic issue here, but it's good to not have an example show "bad" code.

### Test Plan

N/A

### Screenshots/Videos (OPTIONAL)

N/A

I didn't bother with creating a feature branch due to the small impact of the change.