### PR TITLE
Support template file with external contents

### DIFF
--- a/bin/build-templates.sh
+++ b/bin/build-templates.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+rm -r dist/templates &> /dev/null
+cp -r templates dist/
+node ./bin/bundle-templates.js templates dist/templates

--- a/config.json
+++ b/config.json
@@ -1,5 +1,6 @@
 {
   "serviceUrl": "//wasmexplorer-service.herokuapp.com/service.php",
   "clang": "//webassembly-studio-clang.herokuapp.com/build",
-  "rustc": "//webassembly-studio-rust.herokuapp.com/rustc"
+  "rustc": "//webassembly-studio-rust.herokuapp.com/rustc",
+  "templates": "/dist/templates/index.js"
 }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "coverage": "jest --coverage",
     "clean": "rm -r dist/*",
     "tslint": "tslint -p .",
-    "templates": "node bin/bundle-templates.js > dist/templates.js"
+    "templates": "rm -r dist/templates &> /dev/null ; cp -r templates dist/ && node bin/bundle-templates.js templates dist/templates"
   },
   "jest": {
     "setupFiles": [
@@ -32,7 +32,8 @@
     ],
     "collectCoverageFrom": [
       "src/**/**.(ts|tsx|js)"
-    ]
+    ],
+    "testURL": "https://webassembly.studio/"
   },
   "repository": {
     "type": "git",

--- a/src/actions/AppActions.ts
+++ b/src/actions/AppActions.ts
@@ -30,6 +30,7 @@ import Group from "../utils/group";
 import { Gulpy } from "../gulpy";
 import { Errors } from "../errors";
 import { contextify } from "../util";
+import getConfig from "../config";
 
 export enum AppActionType {
   ADD_FILE_TO = "ADD_FILE_TO",
@@ -208,9 +209,9 @@ export interface OpenFilesAction extends AppAction {
   files: string[][];
 }
 
-export async function openProjectFiles(files: IFiddleFile []) {
+export async function openProjectFiles(template: Template) {
   const newProject = new Project();
-  await Service.loadFilesIntoProject(files, newProject);
+  await Service.loadFilesIntoProject(template.files, newProject, template.baseUrl);
   dispatcher.dispatch({
     type: AppActionType.LOAD_PROJECT,
     project: newProject

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -547,7 +547,7 @@ export class App extends React.Component<AppProps, AppState> {
             this.setState({ newProjectDialog: null });
           }}
           onCreate={async (template: Template) => {
-            await openProjectFiles(template.files);
+            await openProjectFiles(template);
             this.setState({ newProjectDialog: false });
           }}
         />

--- a/src/config.ts
+++ b/src/config.ts
@@ -23,6 +23,7 @@ export interface IConfig {
   serviceUrl: string;
   clang: string;
   rustc: string;
+  templates: string;
 }
 
 const configUrl = "./config.json";

--- a/src/utils/fetchTemplates.ts
+++ b/src/utils/fetchTemplates.ts
@@ -19,9 +19,7 @@
  * SOFTWARE.
  */
 
-export default async function fetchTemplates() {
-  const response = await fetch("dist/templates.js");
-  const js = await response.text();
-  const templates = (new Function(`return ${js};`)).call(null);
-  return templates;
+export default async function fetchTemplates(src: string) {
+  const response = await fetch(src);
+  return JSON.parse(await response.text());
 }

--- a/tests/components/NewProjectDialog/NewProjectDialog.spec.tsx
+++ b/tests/components/NewProjectDialog/NewProjectDialog.spec.tsx
@@ -10,13 +10,27 @@ jest.mock("../../../src/utils/fetchTemplates", () => {
         JSON.parse(require('fs').readFileSync(__dirname + "/templates.json").toString()),
   };
 });
+
 jest.mock("../../../src/service", () => {
   return {
     Service: {
       compileMarkdownToHtml(md) { return `<pre>${md}</pre>`; },
     },
   }
-})
+});
+
+jest.mock("../../../src/config", () => {
+  return {
+    "default": async () => {
+      return {
+        serviceUrl: "",
+        clang: "",
+        rustc: "",
+        templates: ""
+      };
+    },
+  }
+});
 
 import { NewProjectDialog, Template } from "../../../src/components/NewProjectDialog";
 


### PR DESCRIPTION
Associated Issue: None

### Summary of Changes

* Add support for loading a template's files on-demand instead of embedding them all into the templates file itself.
* The code that creates the templates file is also changed to copy files over to `dist/templates/[template name]`.
* Same for the code for loading files to properly resolve paths relative to the templates file.

### Test Plan

- [x] Open WebAssembly.studio
- [x] Select a template
- [x] Click the "Create" button
- [x] Open all of the project's files to ensure they're all as expected
- [x] Build and Run project to ensure it works as expected
- [x] Repeat for all templates
