### PR TITLE
Refactor and move rewrite sources logic into separate file

### DIFF
--- a/src/utils/rewriteSources.ts
+++ b/src/utils/rewriteSources.ts
@@ -1,0 +1,83 @@
+/* Copyright 2018 Mozilla Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import { Project } from "../model";
+import { FileTemplate } from "../components/DirectoryTree";
+
+export class RewriteSourcesContext {
+    project: Project;
+    processedFiles: any;
+    logLn: (s: string) => void;
+    createFile: (content: ArrayBuffer|string, type: string) => string;
+
+    constructor(project: Project) {
+        this.project = project;
+        this.processedFiles = Object.create(null);
+    }
+}
+
+function expandURL(path: string, base: string): string {
+  return new URL(path, "http://example.org/" + base).pathname.substr(1);
+}
+
+export function rewriteJS(context: RewriteSourcesContext, jsFileName: string): string {
+  const file = context.project.getFile(jsFileName);
+  if (!file) {
+    return null;
+  }
+  const src = file.getData() as string;
+  return src.replace(/\bfrom\s+['"](.+?)['"](\s*[;\n])/g, (all: string, path?: string, sep?: string) => {
+    const fullPath = expandURL(path, jsFileName);
+    const blobUrl = processJSFile(context, fullPath);
+    if (!blobUrl) {
+      (void 0, context.logLn)(`Cannot find file '${path}' mentioned in ${jsFileName}`);
+      return all;
+    }
+    return `from "${blobUrl}"${sep}`;
+  });
+}
+
+function processJSFile(context: RewriteSourcesContext, fullPath: string): string {
+  if (context.processedFiles[fullPath]) {
+    return context.processedFiles[fullPath];
+  }
+  const src = rewriteJS(context, fullPath);
+  const resultUrl = context.createFile(src, "application/javascript");
+  context.processedFiles[fullPath] = resultUrl;
+  return resultUrl;
+}
+
+export function rewriteHTML(context: RewriteSourcesContext, htmlFileName: string): string {
+  const file = context.project.getFile(htmlFileName);
+  if (!file) {
+    return null;
+  }
+  const src = file.getData() as string;
+  return src.replace(/\bsrc\s*=\s*['"](.+?)['"]/g, (all: string, path?: string) => {
+    const fullPath = expandURL(path, htmlFileName);
+    const blobUrl = processJSFile(context, fullPath);
+    if (!blobUrl) {
+      (void 0, context.logLn)(`Cannot find file '${path}' mentioned in ${htmlFileName}`);
+      return all;
+    }
+    return `src="${blobUrl}"`;
+  });
+}

--- a/tests/utils/rewriteSources.spec.tsx
+++ b/tests/utils/rewriteSources.spec.tsx
@@ -1,0 +1,73 @@
+/* Any copyright is dedicated to the Public Domain.
+ * http://creativecommons.org/publicdomain/zero/1.0/ */
+
+import {
+  rewriteHTML, rewriteJS, RewriteSourcesContext
+} from "../../src/utils/rewriteSources";
+
+class ProjectMock {
+  public files: any;
+  constructor() {
+    this.files = Object.create(null);
+  }
+  getFile(name: string) {
+    return this.files[name];
+  }
+  setFile(name: string, data: string) {
+    this.files[name] = {
+      getData() {
+        return data;
+      },
+    };
+  }
+  toProject() {
+    return this as any;
+  }
+}
+
+describe("Rewrite sources tests", () => {
+  it("html not changed", () => {
+    const projectStub = new ProjectMock();
+    projectStub.setFile("main.html", "<body>test</body>");
+
+    const context = new RewriteSourcesContext(projectStub.toProject());
+    const srcHTML = rewriteHTML(context, "main.html");
+
+    expect(srcHTML).toBe("<body>test</body>");
+  });
+  it("html changed", () => {
+    const projectStub = new ProjectMock();
+    projectStub.setFile("main.html", 
+      "<script src=\"test.js\"></script><body>test</body>");
+    projectStub.setFile("test.js", "void 0");
+
+    const context = new RewriteSourcesContext(projectStub.toProject());
+    context.createFile = (content: ArrayBuffer|string, type: string): string => {
+      expect(content).toBe("void 0");
+      return "fake-url:test";
+    };
+    const srcHTML = rewriteHTML(context, "main.html");
+
+    expect(srcHTML).toBe("<script src=\"fake-url:test\"></script><body>test</body>");
+  });
+  it("html and js changed", () => {
+    const projectStub = new ProjectMock();
+    projectStub.setFile("main.html", 
+      "<script src=\"test.js\"></script><body>test</body>");
+    projectStub.setFile("test.js", "import { test } from 'test2.js'; test();");
+    projectStub.setFile("test2.js", "void 0");
+
+    const context = new RewriteSourcesContext(projectStub.toProject());
+    context.createFile = (content: ArrayBuffer|string, type: string): string => {
+      if (content == "void 0") {
+        return "fake-url:test2";
+      }
+      expect(content).toBe("import { test } from \"fake-url:test2\"; test();");
+      return "fake-url:test";
+    };
+    context.logLn = console.error;
+    const srcHTML = rewriteHTML(context, "main.html");
+
+    expect(srcHTML).toBe("<script src=\"fake-url:test\"></script><body>test</body>");
+  });
+});


### PR DESCRIPTION
Associated Issue: unable to use ES6 modules

* it possible to use `<script type="module">` and `improt { fn } from 'test.js';` in source files.