### PR TITLE
hello_world_rust: fix README.md

### DIFF
--- a/templates/hello_world_rust/README.md
+++ b/templates/hello_world_rust/README.md
@@ -9,7 +9,7 @@ bundler so you can poke around all the raw output!
 
 Some files you may be interested in are:
 
-* `main.rs` - this is the main body of Rust code, annotated with
+* `lib.rs` - this is the main body of Rust code, annotated with
   `#[wasm_bindgen]` to have its functionality exported to JS.
 * `main.js` - this is the application's supporting JS, automatically run by
   `main.html`. Here you'll import items implemented in Rust through the


### PR DESCRIPTION
It said main.rs, where it should say lib.rs to be accurate.

Trivial, so please bear with me in foregoing the PR template 😃 