### PR TITLE
Fixes #190 - Clipped Monaco context menu

### DIFF
--- a/src/components/editor/Editor.tsx
+++ b/src/components/editor/Editor.tsx
@@ -149,6 +149,12 @@ export class Monaco extends React.Component<MonacoProps, {}> {
       this.container.removeChild(this.container.lastChild);
     }
     this.editor = monaco.editor.create(this.container, options as any);
+    this.editor.onContextMenu((e: any) => {
+      const anchorOffset = { x: -10, y: -3 };
+      const menu: HTMLElement = document.querySelector(".monaco-editor > .monaco-menu-container");
+      menu.style.top = (parseInt(menu.style.top, 10) + e.event.editorPos.y + anchorOffset.y) + "px";
+      menu.style.left = (parseInt(menu.style.left, 10) + e.event.editorPos.x + anchorOffset.x) + "px";
+    });
     this.registerActions();
     console.info("Created a new Monaco editor.");
   }

--- a/style/global.css
+++ b/style/global.css
@@ -908,9 +908,18 @@ a {
 .context-view.monaco-menu-container {
   max-height: 380px;
   overflow: scroll;
+  position: fixed;
 }
 
 /* Menu Item Styles */
+
+.action-label::selection {
+  background: none;
+}
+
+.action-label::-moz-selection {
+  background: none;
+}
 
 .action-label.ruler {
   border-top: 1px solid var(--grey-800);

--- a/tests/__mocks__/monaco-editor.ts
+++ b/tests/__mocks__/monaco-editor.ts
@@ -30,6 +30,7 @@ class EditorModel {
 
 (<any>global).monaco = {
   editor: {
+    onContextMenu() { },
     setModelLanguage() { },
     setModelMarkers() { },
     addAction() { },

--- a/tests/components/Editor/Monaco.spec.tsx
+++ b/tests/components/Editor/Monaco.spec.tsx
@@ -215,4 +215,22 @@ describe("Tests for Editor.tsx/Monaco", () => {
     updateOptionsSpy.mockRestore();
     wrapper.unmount();
   });
+  it("should listen to onContextMenu events on the editor to resolve menu position", () => {
+    const onContextMenuSpy = jest.spyOn(monaco.editor, "onContextMenu");
+    const querySelectorSpy = jest.spyOn(document, "querySelector");
+    querySelectorSpy.mockImplementation(() => element);
+    const {wrapper} = setup();
+    const registeredListenerFn = onContextMenuSpy.mock.calls[0][0];
+    const element: HTMLElement = document.createElement("div");
+    element.style.top = "100px";
+    element.style.left = "100px";
+    registeredListenerFn({ event: { editorPos: { x: 100, y: 100 }}});
+    expect(onContextMenuSpy).toHaveBeenCalled();
+    expect(querySelectorSpy).toHaveBeenCalledWith(".monaco-editor > .monaco-menu-container");
+    expect(element.style.top).toEqual("197px");
+    expect(element.style.left).toEqual("190px");
+    onContextMenuSpy.mockRestore();
+    querySelectorSpy.mockRestore();
+    wrapper.unmount();
+  });
 });


### PR DESCRIPTION
Associated Issue: #190 

### Summary of Changes
* Uses fixed positioning for the context menu css
* Registers an event listener (onContextMenu) when the editor is created
* Each time the context menu is opened, the correct position is calculated and set

### Test Plan
* Create C "hello, world" project
* Open a file
* Right click to open the context menu
* The context menu should no longer get clipped

### Screenshots
<img width="1277" alt="skarmavbild 2018-05-18 kl 14 16 24" src="https://user-images.githubusercontent.com/16004130/40234264-78be194c-5aa6-11e8-95e2-2074c20016b5.png">

