### PR TITLE
Fixes #193 - Mouse wheel click triggers popup blocker

### DIFF
--- a/src/actions/AppActions.ts
+++ b/src/actions/AppActions.ts
@@ -239,10 +239,6 @@ export async function saveProject(fiddle: string) {
   } as AppAction);
 }
 
-export async function editInWebAssemblyStudio(fiddle: string) {
-  window.open(`//webassembly.studio/?f=${fiddle}`, "wasm.studio");
-}
-
 export interface FocusTabGroupAction extends AppAction {
   type: AppActionType.FOCUS_TAB_GROUP;
   group: Group;

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -28,7 +28,7 @@ import { EditorView, ViewTabs, View, Tab, Tabs } from "./editor";
 import { Header } from "./Header";
 import { Toolbar } from "./Toolbar";
 import { ViewType, defaultViewTypeForFileType } from "./editor/View";
-import { build, run, runTask, editInWebAssemblyStudio, openFiles, pushStatus, popStatus } from "../actions/AppActions";
+import { build, run, runTask, openFiles, pushStatus, popStatus } from "../actions/AppActions";
 
 import appStore from "../stores/AppStore";
 import {
@@ -411,10 +411,10 @@ export class App extends React.Component<AppProps, AppState> {
           icon={<GoPencil />}
           label="Edit in WebAssembly Studio"
           title="Edit Project in WebAssembly Studio"
-          onClick={() => {
-            assert(this.state.fiddle);
-            editInWebAssemblyStudio(this.state.fiddle);
-          }}
+          isDisabled={!this.state.fiddle}
+          href={`//webassembly.studio/?f=${this.state.fiddle}`}
+          target="wasm.studio"
+          rel="noopener noreferrer"
         />);
     }
     if (this.props.embeddingParams.type === EmbeddingType.None &&
@@ -530,9 +530,9 @@ export class App extends React.Component<AppProps, AppState> {
           label="GitHub Issues"
           title="GitHub Issues"
           customClassName="issue"
-          onClick={() => {
-            window.open("https://github.com/wasdk/WebAssemblyStudio", "_blank");
-          }}
+          href="https://github.com/wasdk/WebAssemblyStudio"
+          target="_blank"
+          rel="noopener noreferrer"
         />,
         <Button
           icon={<GoQuestion />}

--- a/src/components/shared/Button.tsx
+++ b/src/components/shared/Button.tsx
@@ -28,6 +28,9 @@ export class Button extends React.Component<{
   isDisabled?: boolean;
   onClick?: Function;
   customClassName?: string;
+  href?: string,
+  target?: string,
+  rel?: string
 }, {}> {
   render() {
     let className = "button ";
@@ -36,6 +39,19 @@ export class Button extends React.Component<{
     }
     if (this.props.isDisabled) {
       className += " disabled";
+    }
+    if (this.props.href && !this.props.isDisabled) {
+      return (
+        <a
+          href={this.props.href}
+          target={this.props.target || ""}
+          rel={this.props.rel || ""}
+          className={className}
+          title={this.props.title}
+        >
+          {this.props.icon} {this.props.label}
+        </a>
+      );
     }
     return <div
       className={className}

--- a/style/global.css
+++ b/style/global.css
@@ -480,6 +480,7 @@ a {
   line-height: 24px;
   -moz-user-select: none;
   user-select: none;
+  text-decoration: none;
 }
 
 .button.disabled {

--- a/tests/components/Button/Button.spec.tsx
+++ b/tests/components/Button/Button.spec.tsx
@@ -6,18 +6,19 @@ import {shallow} from "enzyme";
 import {Button} from "../../../src/components/shared/Button";
 
 describe("Tests for button component", () => {
-  const setup = (value: any) => {
-    const props = {
-      isDisabled: value,
-      // tslint:disable-next-line:no-empty
-      onClick: () => {},
-      icon: <button/>,
-      label: "",
-      title: ""
-    };
+  const setup = (props?) => {
     return shallow(<Button {...props}/>);
   };
   it("Button renders correctly", () => {
-    setup(false);
+    setup();
+  });
+  it("should render as a link if passing the href prop", () => {
+    const href = "https://github.com/wasdk/WebAssemblyStudio"
+    const wrapper = setup({ href, target: "_blank", rel: "noopener noreferrer" });
+    const a = wrapper.find("a");
+    expect(a.exists()).toEqual(true);
+    expect(a.prop("href")).toEqual(href);
+    expect(a.prop("target")).toEqual("_blank");
+    expect(a.prop("rel")).toEqual("noopener noreferrer");
   });
 });


### PR DESCRIPTION
Associated Issue: #193 

### Summary of Changes
* Modified the Button component, now takes an optional href prop to render as an a-tag
* Added a test case

### Test Plan
- Create C "hello, world" project
- Click on "Github Issues" button, it should open github in a new tab
- Mouse wheel click on "Github Issues" button, it should open github in a new tab