### PR TITLE
Change Arc templates to swap columns and rows

### DIFF
--- a/misc/arc-templates/arc_js/build.ts
+++ b/misc/arc-templates/arc_js/build.ts
@@ -4,19 +4,21 @@ import { Service, Arc, project, logLn } from "@wasm/studio-utils";
 gulp.task("build", async () => {});
 
 gulp.task("publish", async () => {
-    const rows = 44, cols = 36, frameCount = 1050, fps = 35;
+    // Note: the Arch site interprets cols and rows inverted, so we switch them around
+    // in the data we send.
+    const rows = 36, cols = 44, frameCount = 1050, fps = 35;
     const { transform } = await (await Service.import('src/module.js')).default();
     const buffer = new ArrayBuffer(cols * rows * frameCount * 3);
     transform(buffer, rows, cols, frameCount, fps, true);
-    const animation = Arc.animationBufferToJSON(buffer, rows, cols, frameCount);
+    const animation = Arc.animationBufferToJSON(buffer, cols, rows, frameCount);
 
     const jsModule = project.getFile("src/module.js").getData();
     Arc.publish({
         description: "ES Module Example",
         author: "",
         animation: {
-            rows,
-            cols,
+            rows: cols,
+            cols: rows,
             frameCount,
             fps,
             data: animation,

--- a/misc/arc-templates/arc_rust/build.ts
+++ b/misc/arc-templates/arc_rust/build.ts
@@ -9,11 +9,13 @@ gulp.task("build", async () => {
 });
 
 gulp.task("publish", async () => {
-    const rows = 44, cols = 36, frameCount = 1050, fps = 35;
+    // Note: the Arch site interprets cols and rows inverted, so we switch them around
+    // in the data we send.
+    const rows = 36, cols = 44, frameCount = 1050, fps = 35;
     const { transform } = await (await Service.import('src/module.js')).default();
     const buffer = new ArrayBuffer(cols * rows * frameCount * 3);
     transform(buffer, rows, cols, frameCount, fps, true);
-    const animation = Arc.animationBufferToJSON(buffer, rows, cols, frameCount);
+    const animation = Arc.animationBufferToJSON(buffer, cols, rows, frameCount);
 
     const jsModule = project.getFile("src/module.js").getData();
     const rsSource = project.getFile("src/lib.rs").getData();
@@ -22,8 +24,8 @@ gulp.task("publish", async () => {
         description: "WASM Module Example",
         author: "",
         animation: {
-            rows,
-            cols,
+            rows: cols,
+            cols: rows,
             frameCount,
             fps,
             data: animation,

--- a/misc/arc-templates/arc_wat/build.ts
+++ b/misc/arc-templates/arc_wat/build.ts
@@ -8,12 +8,13 @@ gulp.task("build", async () => {
 });
 
 gulp.task("publish", async () => {
-    // Executing the module to get the frames data.
-    const rows = 44, cols = 36, frameCount = 1050, fps = 35;
+    // Note: the Arch site interprets cols and rows inverted, so we switch them around
+    // in the data we send.
+    const rows = 36, cols = 44, frameCount = 1050, fps = 35;
     const { transform } = await (await Service.import('src/module.js')).default();
     const buffer = new ArrayBuffer(cols * rows * frameCount * 3);
     transform(buffer, rows, cols, frameCount, fps, true);
-    const animation = Arc.animationBufferToJSON(buffer, rows, cols, frameCount);
+    const animation = Arc.animationBufferToJSON(buffer, cols, rows, frameCount);
 
     const jsModule = project.getFile("src/module.js").getData();
     const watSource = project.getFile("src/module.wat").getData();
@@ -22,8 +23,8 @@ gulp.task("publish", async () => {
         description: "WASM Module Example",
         author: "",
         animation: {
-            rows,
-            cols,
+            rows: cols,
+            cols: rows,
             frameCount,
             fps,
             data: animation,


### PR DESCRIPTION
The website currently misinterprets columns and rows, and we don't want people to have to do the same in their modules, so we swap them before sending the animation off to the website.
