### PR TITLE
Adding jest-enzyme as dev-dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2034,6 +2034,12 @@
         "safe-buffer": "5.1.2"
       }
     },
+    "circular-json-es6": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/circular-json-es6/-/circular-json-es6-2.0.2.tgz",
+      "integrity": "sha512-ODYONMMNb3p658Zv+Pp+/XPa5s6q7afhz3Tzyvo+VRh9WIrJ64J76ZC4GQxnlye/NesTn09jvOiuE8+xxfpwhQ==",
+      "dev": true
+    },
     "clap": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/clap/-/clap-1.2.3.tgz",
@@ -2914,6 +2920,15 @@
       "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
       "dev": true
     },
+    "deep-equal-ident": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/deep-equal-ident/-/deep-equal-ident-1.1.1.tgz",
+      "integrity": "sha1-BvS4nlNxDNbOpKd4HHqVZkLejck=",
+      "dev": true,
+      "requires": {
+        "lodash.isequal": "3.0.4"
+      }
+    },
     "deep-extend": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.5.1.tgz",
@@ -3375,6 +3390,25 @@
         "lodash": "4.17.10",
         "object.assign": "4.1.0",
         "prop-types": "15.6.1"
+      }
+    },
+    "enzyme-matchers": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/enzyme-matchers/-/enzyme-matchers-6.0.1.tgz",
+      "integrity": "sha1-Hubox/WaRqGrYtlx46/bRbf7PqI=",
+      "dev": true,
+      "requires": {
+        "circular-json-es6": "2.0.2",
+        "deep-equal-ident": "1.1.1"
+      }
+    },
+    "enzyme-to-json": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/enzyme-to-json/-/enzyme-to-json-3.3.4.tgz",
+      "integrity": "sha1-Z8YEDpMRgvGDQYry659DIyWKp38=",
+      "dev": true,
+      "requires": {
+        "lodash": "4.17.10"
       }
     },
     "errno": {
@@ -6356,6 +6390,15 @@
         "detect-newline": "2.1.0"
       }
     },
+    "jest-environment-enzyme": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/jest-environment-enzyme/-/jest-environment-enzyme-6.0.1.tgz",
+      "integrity": "sha1-mfUdf5iJGKlj3yhZsx4paW1/a+0=",
+      "dev": true,
+      "requires": {
+        "jest-environment-jsdom": "22.4.3"
+      }
+    },
     "jest-environment-jsdom": {
       "version": "22.4.3",
       "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-22.4.3.tgz",
@@ -6375,6 +6418,17 @@
       "requires": {
         "jest-mock": "22.4.3",
         "jest-util": "22.4.3"
+      }
+    },
+    "jest-enzyme": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/jest-enzyme/-/jest-enzyme-6.0.1.tgz",
+      "integrity": "sha1-aWNJj4lVC/MVt1ARoHkMc9+Vhg0=",
+      "dev": true,
+      "requires": {
+        "enzyme-matchers": "6.0.1",
+        "enzyme-to-json": "3.3.4",
+        "jest-environment-enzyme": "6.0.1"
       }
     },
     "jest-get-type": {
@@ -7517,6 +7571,29 @@
       "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
       "dev": true
     },
+    "lodash._baseisequal": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/lodash._baseisequal/-/lodash._baseisequal-3.0.7.tgz",
+      "integrity": "sha1-2AJfdjOdKTQnZ9zIh85cuVpbUfE=",
+      "dev": true,
+      "requires": {
+        "lodash.isarray": "3.0.4",
+        "lodash.istypedarray": "3.0.6",
+        "lodash.keys": "3.1.2"
+      }
+    },
+    "lodash._bindcallback": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
+      "integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4=",
+      "dev": true
+    },
+    "lodash._getnative": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
+      "dev": true
+    },
     "lodash.camelcase": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
@@ -7534,6 +7611,45 @@
       "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
       "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
       "dev": true
+    },
+    "lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
+      "dev": true
+    },
+    "lodash.isarray": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
+      "dev": true
+    },
+    "lodash.isequal": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-3.0.4.tgz",
+      "integrity": "sha1-HDXrO27wzR/1F0Pj6jz3/f/ay2Q=",
+      "dev": true,
+      "requires": {
+        "lodash._baseisequal": "3.0.7",
+        "lodash._bindcallback": "3.0.1"
+      }
+    },
+    "lodash.istypedarray": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.istypedarray/-/lodash.istypedarray-3.0.6.tgz",
+      "integrity": "sha1-yaR3SYYHUB2OhJTSg7h8OSgc72I=",
+      "dev": true
+    },
+    "lodash.keys": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+      "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+      "dev": true,
+      "requires": {
+        "lodash._getnative": "3.9.1",
+        "lodash.isarguments": "3.1.0",
+        "lodash.isarray": "3.0.4"
+      }
     },
     "lodash.memoize": {
       "version": "4.1.2",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "mutate": "./node_modules/.bin/stryker run"
   },
   "jest": {
+    "setupTestFrameworkScriptFile": "./node_modules/jest-enzyme/lib/index.js",
     "setupFiles": [
       "<rootDir>/test-shim.js",
       "<rootDir>/test-setup.js"
@@ -79,6 +80,7 @@
     "enzyme": "^3.3.0",
     "enzyme-adapter-react-16": "^1.1.1",
     "jest": "^22.4.2",
+    "jest-enzyme": "^6.0.1",
     "monaco-editor-webpack-plugin": "^1.2.0",
     "react-test-renderer": "^16.2.0",
     "source-map-loader": "^0.2.3",


### PR DESCRIPTION
Adding [jest-enzyme](https://github.com/FormidableLabs/enzyme-matchers) as dev-dependency. This adds a bunch of assertions that will make the tests easier to understand / yield better error messages.

Add `import "jest-enzyme";` in the test file to import typings