### PR TITLE
Catch invalid service responses and error

### DIFF
--- a/src/compilerServices/clangService.ts
+++ b/src/compilerServices/clangService.ts
@@ -64,7 +64,7 @@ export class ClangService implements CompilerService {
       items: {
         "a.wasm": { content, fileRef, console, },
       },
-      console: (result as any).message
+      console: result.message
     };
   }
 }

--- a/src/compilerServices/rustService.ts
+++ b/src/compilerServices/rustService.ts
@@ -77,7 +77,7 @@ export class RustService implements CompilerService {
         "a.wasm": { content, fileRef, console, },
         ...extraItems
       },
-      console: (result as any).message
+      console: result.message
     };
   }
 }


### PR DESCRIPTION
Associated Issue: service network errors are not visible for devs

### Summary of Changes

* catch json parse errors
* ensure http status code == 200
