### PR TITLE
Fix bug in notifying embedding website of a fork

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -358,6 +358,9 @@ export class App extends React.Component<AppProps, AppState> {
       history.pushState({}, fiddle, `${prefix}f=${fiddle}`);
     }
     this.setState({ fiddle });
+    if (this.props.embeddingParams.type === EmbeddingType.Arc) {
+      notifyArcAboutFork(fiddle);
+    }
   }
   async gist(fileOrDirectory?: File) {
     pushStatus("Exporting Project");
@@ -447,9 +450,6 @@ export class App extends React.Component<AppProps, AppState> {
           isDisabled={this.toolbarButtonsAreDisabled()}
           onClick={() => {
             this.fork();
-            if (this.props.embeddingParams.type === EmbeddingType.Arc) {
-              notifyArcAboutFork(this.state.fiddle);
-            }
           }}
         />
       );


### PR DESCRIPTION
The notification currently happens immediately after the "fork" button was clicked, instead of being delayed until the fork has actually happened.
