### PR TITLE
[WIP] fix(arc): improve rust template

### DIFF
--- a/misc/arc-templates/arc_rust/src/arc_module.rs
+++ b/misc/arc-templates/arc_rust/src/arc_module.rs
@@ -2,36 +2,42 @@ use color::Rgb;
 use module_instance;
 
 pub struct ArcModule {
-  pub rows: usize,
-  pub cols: usize,
-  frame_count: usize,
-  fps: usize,
-  is_first: bool,
-  animation: Vec<Rgb>
+    pub rows: usize,
+    pub cols: usize,
+    frame_count: usize,
+    fps: usize,
+    is_first: bool,
+    animation: Vec<Rgb>,
 }
 
 impl ArcModule {
-  pub fn create_instance(rows: usize, cols: usize, frame_count: usize, fps: usize, is_first: bool) -> &'static ArcModule {
-    let buffer_size = rows * cols * frame_count;
-    let mut module = ArcModule {
-      rows,
-      cols,
-      frame_count,
-      fps,
-      is_first,
-      animation: Vec::with_capacity(buffer_size)
-    };
-    module.animation.resize(buffer_size, Rgb::new(0, 0, 0));
-    module.animation[0] = Rgb {r: 2, g: 4, b: 10};
-    unsafe { module_instance = Box::into_raw(Box::new(module)) };
-    ArcModule::get_instance()
-  }
+    pub fn create_instance(
+        rows: usize,
+        cols: usize,
+        frame_count: usize,
+        fps: usize,
+        is_first: bool,
+    ) -> &'static ArcModule {
+        let buffer_size = rows * cols * frame_count;
+        let mut module = ArcModule {
+            rows,
+            cols,
+            frame_count,
+            fps,
+            is_first,
+            animation: Vec::with_capacity(buffer_size),
+        };
+        module.animation.resize(buffer_size, Rgb::new(0, 0, 0));
+        module.animation[0] = Rgb { r: 2, g: 4, b: 10 };
+        unsafe { module_instance = Box::into_raw(Box::new(module)) };
+        ArcModule::get_instance()
+    }
 
     pub fn get_instance<'a>() -> &'a mut ArcModule {
-    unsafe { &mut *module_instance }
-  }
+        unsafe { &mut *module_instance }
+    }
 
-  pub fn get_animation<'a>(&'a mut self) -> &'a mut Vec<Rgb> {
-    &mut self.animation
-  }
+    pub fn get_animation<'a>(&'a mut self) -> &'a mut Vec<Rgb> {
+        &mut self.animation
+    }
 }

--- a/misc/arc-templates/arc_rust/src/color.rs
+++ b/misc/arc-templates/arc_rust/src/color.rs
@@ -1,17 +1,19 @@
 #[repr(C)]
 #[derive(Copy)]
 pub struct Rgb {
-  pub r: u8,
-  pub g: u8,
-  pub b: u8,
+    pub r: u8,
+    pub g: u8,
+    pub b: u8,
 }
 
 impl Rgb {
-  pub fn new(r: u8, g: u8, b: u8) -> Rgb {
-    Rgb {r, g, b}
-  }
+    pub fn new(r: u8, g: u8, b: u8) -> Rgb {
+        Rgb { r, g, b }
+    }
 }
 
 impl Clone for Rgb {
-  fn clone(&self) -> Rgb { *self }
+    fn clone(&self) -> Rgb {
+        *self
+    }
 }

--- a/misc/arc-templates/arc_rust/src/lib.rs
+++ b/misc/arc-templates/arc_rust/src/lib.rs
@@ -1,26 +1,31 @@
 static mut module_instance: *mut ArcModule = 0 as *mut ArcModule;
 
-mod color;
 mod arc_module;
+mod color;
 mod utils;
 
-use color::Rgb;
 use arc_module::ArcModule;
+use color::Rgb;
 
-pub use utils::init;
 pub use utils::getAnimationBuffer;
+pub use utils::init;
 
 #[no_mangle]
-pub extern fn apply() {
-  let mut module = ArcModule::get_instance();
-  let rows = module.rows;
-  let cols = module.cols;
-  let ref mut animation = module.get_animation().as_mut_slice();
-  for (index, frame) in animation.chunks_mut(rows * cols).enumerate() {
-    for row in 0 .. rows {
-      for col in 0 .. cols {
-        frame[row * cols + col] = Rgb::new(row as u8 * 5, col as u8 * 5, ((index * 5) % 0xffusize) as u8);
-      }
+pub extern "C" fn apply() {
+    let mut module = ArcModule::get_instance();
+    let rows = module.rows;
+    let cols = module.cols;
+
+    let animation = module.get_animation().as_mut_slice();
+    for (index, frame) in animation.chunks_mut(rows * cols).enumerate() {
+        for row in 0..rows {
+            for col in 0..cols {
+                frame[row * cols + col] = Rgb::new(
+                    row as u8 * 5,
+                    col as u8 * 5,
+                    ((index * 5) % 0xffusize) as u8,
+                );
+            }
+        }
     }
-  }
 }

--- a/misc/arc-templates/arc_rust/src/utils.rs
+++ b/misc/arc-templates/arc_rust/src/utils.rs
@@ -1,12 +1,12 @@
-use color::Rgb;
 use arc_module::ArcModule;
+use color::Rgb;
 
 #[no_mangle]
-pub extern fn init(rows: usize, cols: usize, frame_count: usize, fps: usize, is_first: bool) {
-  ArcModule::create_instance(rows, cols, frame_count, fps, is_first);
+pub extern "C" fn init(rows: usize, cols: usize, frame_count: usize, fps: usize, is_first: bool) {
+    ArcModule::create_instance(rows, cols, frame_count, fps, is_first);
 }
 
 #[no_mangle]
-pub extern fn getAnimationBuffer() -> *const Rgb {
-  ArcModule::get_instance().get_animation().as_ptr()
+pub extern "C" fn getAnimationBuffer() -> *const Rgb {
+    ArcModule::get_instance().get_animation().as_ptr()
 }


### PR DESCRIPTION
This PR adds improvements to the arc rust template:

- `cargo fmt`
- removes unecessary ref mut
- spacing
