### PR TITLE
Fixing bug related to editor scroll after closing context menu

### DIFF
--- a/src/components/editor/Editor.tsx
+++ b/src/components/editor/Editor.tsx
@@ -149,12 +149,16 @@ export class Monaco extends React.Component<MonacoProps, {}> {
       this.container.removeChild(this.container.lastChild);
     }
     this.editor = monaco.editor.create(this.container, options as any);
-    this.editor.onContextMenu(e => this.onContextMenu(e));
-    this.editor.onDidFocusEditor(() => this.onDidFocusEditor());
+    this.editor.onContextMenu(e => {
+      this.resolveMenuPosition(e);
+      this.disableEditorScroll(); // This makes it possible to scroll inside the menu
+    });
+    this.editor.onDidFocusEditor(() => this.enableEditorScroll());
+    this.editor.onDidFocusEditorText(() => this.enableEditorScroll());
     this.registerActions();
     console.info("Created a new Monaco editor.");
   }
-  onContextMenu(e: any) {
+  resolveMenuPosition(e: any) {
     const anchorOffset = { x: -10, y: -3 };
     const menu: HTMLElement = this.container.querySelector(".monaco-editor > .monaco-menu-container");
     const top = (parseInt(menu.style.top, 10) + e.event.editorPos.y + anchorOffset.y);
@@ -163,15 +167,15 @@ export class Monaco extends React.Component<MonacoProps, {}> {
     menu.style.top = top + "px";
     menu.style.left = left  + "px";
     menu.style.maxHeight = Math.min(window.innerHeight - top - windowPadding, 380) + "px";
-    // Disable editor scroll (this makes it possible to scroll inside the menu)
+  }
+  disableEditorScroll() {
     this.editor.updateOptions({
       scrollbar: {
         handleMouseWheel: false
       }
     });
   }
-  onDidFocusEditor() {
-    // Enable editor scroll
+  enableEditorScroll() {
     this.editor.updateOptions({
       scrollbar: {
         handleMouseWheel: true

--- a/test-shim.js
+++ b/test-shim.js
@@ -37,6 +37,7 @@ class EditorModel {
 
 global.monaco = {
   editor: {
+    onDidFocusEditorText() { },
     onDidFocusEditor() { },
     onContextMenu() { },
     setModelLanguage() { },

--- a/tests/components/Editor/Monaco.spec.tsx
+++ b/tests/components/Editor/Monaco.spec.tsx
@@ -241,16 +241,23 @@ describe("Tests for Editor.tsx/Monaco", () => {
     querySelectorSpy.mockRestore();
     wrapper.unmount();
   });
-  it("should re-enable editor scroll when the editor recives focus again", () => {
-    const updateOptionsSpy = jest.spyOn(monaco.editor, "updateOptions");
+  it("should re-enable editor scroll when the editor receives focus again", () => {
     const onDidFocusEditorSpy = jest.spyOn(monaco.editor, "onDidFocusEditor");
+    const onDidFocusEditorTextSpy = jest.spyOn(monaco.editor, "onDidFocusEditorText");
     const {wrapper} = setup();
-    const registeredListenerFn = onDidFocusEditorSpy.mock.calls[0][0];
-    registeredListenerFn();
+    const updateOptionsSpy = jest.spyOn(monaco.editor, "updateOptions");
+    const onDidFocusEditorListenerFn = onDidFocusEditorSpy.mock.calls[0][0];
+    const onDidFocusEditorTextListenerFn = onDidFocusEditorTextSpy.mock.calls[0][0];
+    onDidFocusEditorListenerFn();
+    onDidFocusEditorTextListenerFn();
     expect(onDidFocusEditorSpy).toHaveBeenCalled();
-    expect(updateOptionsSpy).toHaveBeenCalledWith({ scrollbar: { handleMouseWheel: true }});
+    expect(onDidFocusEditorTextSpy).toHaveBeenCalled();
+    expect(updateOptionsSpy).toHaveBeenCalledTimes(2);
+    expect(updateOptionsSpy.mock.calls[0][0]).toEqual({ scrollbar: { handleMouseWheel: true }});
+    expect(updateOptionsSpy.mock.calls[1][0]).toEqual({ scrollbar: { handleMouseWheel: true }});
     updateOptionsSpy.mockRestore();
     onDidFocusEditorSpy.mockRestore();
+    onDidFocusEditorTextSpy.mockRestore()
     wrapper.unmount();
   });
 });


### PR DESCRIPTION
Currently the editor scroll is not always re-activated when closing the context menu. This is caused by only listening to the onDidFocusEditor event.

### Summary of Changes
* Added onDidFocusEditorText listener to re-activate scroll also when the user closes the context menu by clicking on editor text.

### Test Plan
- Create empty C project
- Open main.js
- Right click on some text in main.js to open context menu
- Close context menu by clicking on some text inside main.js
- It should be possible to scroll the file
