### PR TITLE
Ignoring Typescript declaration files when collecting coverage

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
       "**/tests/**/**/**.spec.(ts|tsx|js)"
     ],
     "collectCoverageFrom": [
-      "src/**/**.(ts|tsx|js)"
+      "src/**/**.(ts|tsx|js)",
+      "!src/**/**.d.ts"
     ],
     "testURL": "https://webassembly.studio/"
   },


### PR DESCRIPTION
This removes the stack trace that gets printed when jest tries to collect coverage from src/@types/tar-js/index.d.ts

### Summary of Changes
* Ignoring TypeScript declaration files when collecting coverage
