### PR TITLE
Improving test assertions with jest-enzyme

### DIFF
--- a/tests/components/Button/Button.spec.tsx
+++ b/tests/components/Button/Button.spec.tsx
@@ -1,6 +1,7 @@
 /* Any copyright is dedicated to the Public Domain.
  * http://creativecommons.org/publicdomain/zero/1.0/ */
 
+import "jest-enzyme";
 import * as React from "react";
 import {shallow} from "enzyme";
 import {Button} from "../../../src/components/shared/Button";
@@ -18,13 +19,13 @@ describe("Tests for button component", () => {
       customClassName: "file-button"
     });
     const button = wrapper.first();
-    expect(button.hasClass("button")).toEqual(true);
-    expect(button.hasClass("file-button")).toEqual(true);
-    expect(button.hasClass("disabled")).toEqual(false);
-    expect(button.prop("title")).toEqual("file");
-    expect(button.find(GoFile).exists()).toEqual(true);
-    expect(button.childAt(1).text()).toEqual(" ");
-    expect(button.childAt(2).text()).toEqual("file");
+    expect(button).toHaveClassName("button");
+    expect(button).toHaveClassName("file-button");
+    expect(button).not.toHaveClassName("disabled");
+    expect(button).toHaveProp("title", "file");
+    expect(button.find(GoFile)).toExist();
+    expect(button.childAt(1)).toHaveText(" ");
+    expect(button.childAt(2)).toHaveText("file");
   });
   it("should render as a link if passing the href prop", () => {
     const href = "https://github.com/wasdk/WebAssemblyStudio";
@@ -36,26 +37,26 @@ describe("Tests for button component", () => {
       label: "link"
     });
     const a = wrapper.first();
-    expect(a.prop("href")).toEqual(href);
-    expect(a.prop("target")).toEqual("_blank");
-    expect(a.prop("rel")).toEqual("noopener noreferrer");
-    expect(a.prop("className")).toEqual("button ");
-    expect(a.find(GoFile).exists()).toEqual(true);
-    expect(a.childAt(1).text()).toEqual(" ");
-    expect(a.childAt(2).text()).toEqual("link");
+    expect(a).toHaveProp("href", href);
+    expect(a).toHaveProp("target", "_blank");
+    expect(a).toHaveProp("rel", "noopener noreferrer");
+    expect(a).toHaveProp("className", "button ");
+    expect(a.find(GoFile)).toExist();
+    expect(a.childAt(1)).toHaveText(" ");
+    expect(a.childAt(2)).toHaveText("link");
   });
   it("should default target and rel properties to empty strings", () => {
     const wrapper = setup({ href: "https://github.com/wasdk/WebAssemblyStudio" });
     const a = wrapper.first();
-    expect(a.prop("target")).toEqual("");
-    expect(a.prop("rel")).toEqual("");
+    expect(a).toHaveProp("target", "");
+    expect(a).toHaveProp("rel", "");
   });
   it("should disable the button if passing the isDisabled prop", () => {
     const onClick = jest.fn();
     const wrapper = setup({ onClick, isDisabled: true });
     const button = wrapper.first();
     button.simulate("click");
-    expect(button.hasClass("disabled")).toEqual(true);
+    expect(button).toHaveClassName("disabled");
     expect(onClick).not.toHaveBeenCalled();
   });
   it("should disable the link if passing the isDisabled prop", () => {
@@ -67,7 +68,7 @@ describe("Tests for button component", () => {
     });
     const button = wrapper.find("div");
     button.simulate("click");
-    expect(button.hasClass("disabled")).toEqual(true);
+    expect(button).toHaveClassName("disabled");
     expect(onClick).not.toHaveBeenCalled();
   });
   it("should invoke onClick when clicking the button", () => {

--- a/tests/components/ControlCenter/ControlCenter.spec.tsx
+++ b/tests/components/ControlCenter/ControlCenter.spec.tsx
@@ -1,12 +1,12 @@
 /* Any copyright is dedicated to the Public Domain.
  * http://creativecommons.org/publicdomain/zero/1.0/ */
 
+import "jest-enzyme";
 import * as React from "react";
 import {shallow} from "enzyme";
-
 import {ControlCenter} from "../../../src/components/ControlCenter";
 import dispatcher from "../../../src/dispatcher";
-import {AppActionType, logLn} from "../../../src/actions/AppActions";
+import {AppActionType} from "../../../src/actions/AppActions";
 
 describe("Tests for ControlCenter component", () => {
   const setup = () => {
@@ -17,16 +17,16 @@ describe("Tests for ControlCenter component", () => {
   });
   it("ControlCenter initially renders correctly", () => {
     const cc = setup();
-    expect(cc.find("EditorView").exists()).toBeTruthy();
-    expect(cc.find("Problems").exists()).toBeFalsy();
+    expect(cc.find("EditorView")).toExist();
+    expect(cc.find("Problems")).not.toExist();
   });
   it("ControlCenter renders correctly after tabs clicking", () => {
     const cc = setup();
     cc.find("Tab").first().simulate("click");
-    expect(cc.find("EditorView").exists()).toBeTruthy();
-    expect(cc.find("Problems").exists()).toBeFalsy();
+    expect(cc.find("EditorView")).toExist();
+    expect(cc.find("Problems")).not.toExist();
     cc.find("Tab").last().simulate("click");
-    expect(cc.find("EditorView").exists()).toBeFalsy();
-    expect(cc.find("Problems").exists()).toBeTruthy();
+    expect(cc.find("EditorView")).not.toExist();
+    expect(cc.find("Problems")).toExist();
   });
 });

--- a/tests/components/Editor/EditorView.spec.tsx
+++ b/tests/components/Editor/EditorView.spec.tsx
@@ -1,6 +1,7 @@
 /* Any copyright is dedicated to the Public Domain.
  * http://creativecommons.org/publicdomain/zero/1.0/ */
 
+import "jest-enzyme";
 import * as React from "react";
 import {mount} from "enzyme";
 import {EditorView} from "../../../src/components/editor/Editor";
@@ -24,7 +25,7 @@ describe("Tests for Editor.tsx/EditorView", () => {
   });
   it("should render a status bar if the open file has a description", () => {
     const wrapper = setup("test");
-    expect(wrapper.find(".status-bar-item").text()).toEqual("test");
+    expect(wrapper.find(".status-bar-item")).toHaveText("test");
     expect(wrapper.find(".editor-container").length).toEqual(1);
     wrapper.unmount();
   });

--- a/tests/components/Header/Header.spec.tsx
+++ b/tests/components/Header/Header.spec.tsx
@@ -1,6 +1,7 @@
 /* Any copyright is dedicated to the Public Domain.
  * http://creativecommons.org/publicdomain/zero/1.0/ */
 
+import "jest-enzyme";
 import * as React from "react";
 import {shallow} from "enzyme";
 import {Header} from "../../../src/components/Header";
@@ -11,6 +12,6 @@ describe("Tests for Header component", () => {
   };
   it("Header renders correctly", () => {
     const header = setup();
-    expect(header.text()).toBe("WebAssembly Studio");
+    expect(header).toHaveText("WebAssembly Studio");
   });
 });

--- a/tests/components/NewDirectoryDialog/NewDirectoryDialog.spec.tsx
+++ b/tests/components/NewDirectoryDialog/NewDirectoryDialog.spec.tsx
@@ -1,6 +1,7 @@
 /* Any copyright is dedicated to the Public Domain.
  * http://creativecommons.org/publicdomain/zero/1.0/ */
 
+import "jest-enzyme";
 import * as React from "react";
 import {shallow} from "enzyme";
 import {Button} from '../../../src/components/shared/Button';
@@ -36,27 +37,27 @@ describe("Tests for NewDirectoryDialog", () => {
     const wrapper = setup({});
     const textInputBox = wrapper.find(TextInputBox);
     const buttons = wrapper.find(Button);
-    expect(textInputBox.exists()).toBe(true);
+    expect(textInputBox).toExist();
     expect(buttons.length).toBe(2);
-    expect(buttons.at(cancelButtonIndex).prop("label")).toBe("Cancel");
-    expect(buttons.at(cancelButtonIndex).prop("title")).toBe("Cancel");
-    expect(buttons.at(createButtonIndex).prop("label")).toBe("Create");
-    expect(buttons.at(createButtonIndex).prop("title")).toBe("Create New Directory");
-    expect(buttons.at(createButtonIndex).prop("isDisabled")).toBe(true);
+    expect(buttons.at(cancelButtonIndex)).toHaveProp("label", "Cancel");
+    expect(buttons.at(cancelButtonIndex)).toHaveProp("title", "Cancel");
+    expect(buttons.at(createButtonIndex)).toHaveProp("label", "Create");
+    expect(buttons.at(createButtonIndex)).toHaveProp("title", "Create New Directory");
+    expect(buttons.at(createButtonIndex)).toHaveProp("isDisabled", true);
   });
   it("displays error & disables create button if name already exists", () => {
     const wrapper = setup({});
     const expectedErrorMessage = "Directory 'src' already exists.";
     wrapper.find(TextInputBox).simulate("change", { target: { value: "src" }});
-    expect(wrapper.find(TextInputBox).prop("error")).toBe(expectedErrorMessage);
-    expect(wrapper.find(Button).at(createButtonIndex).prop("isDisabled")).toBe(true);
+    expect(wrapper.find(TextInputBox)).toHaveProp("error", expectedErrorMessage);
+    expect(wrapper.find(Button).at(createButtonIndex)).toHaveProp("isDisabled", true);
   });
   it("displays error & disables create button if name is invalid", () => {
     const wrapper = setup({});
     const expectedErrorMessage = "Illegal characters in directory name.";
     wrapper.find(TextInputBox).simulate("change", { target: { value: "a+b" }});
-    expect(wrapper.find(TextInputBox).prop("error")).toBe(expectedErrorMessage);
-    expect(wrapper.find(Button).at(createButtonIndex).prop("isDisabled")).toBe(true);
+    expect(wrapper.find(TextInputBox)).toHaveProp("error", expectedErrorMessage);
+    expect(wrapper.find(Button).at(createButtonIndex)).toHaveProp("isDisabled", true);
   });
   it("invokes onCancel when clicking cancel button", () => {
     const onCancel = jest.fn();

--- a/tests/components/NewProjectDialog/NewProjectDialog.spec.tsx
+++ b/tests/components/NewProjectDialog/NewProjectDialog.spec.tsx
@@ -1,6 +1,7 @@
 /* Any copyright is dedicated to the Public Domain.
  * http://creativecommons.org/publicdomain/zero/1.0/ */
 
+import "jest-enzyme";
 import * as React from "react";
 import { shallow } from "enzyme";
 
@@ -55,13 +56,13 @@ describe("Tests for NewProjectDialog component", () => {
   };
   it("NewProjectDialog renders correctly", () => {
     const dialog = setup({});
-    expect(dialog.find("ListBox").exists()).toBeTruthy();
+    expect(dialog.find("ListBox")).toExist();
     const buttons = dialog.find("Button");
     expect(buttons.length).toBe(2);
-    expect(buttons.at(createButtonIndex).prop("label")).toBe("Create");
-    expect(buttons.at(createButtonIndex).prop("title")).toBe("Create");
-    expect(buttons.at(cancelButtonIndex).prop("label")).toBe("Cancel");
-    expect(buttons.at(cancelButtonIndex).prop("title")).toBe("Cancel");
+    expect(buttons.at(createButtonIndex)).toHaveProp("label", "Create");
+    expect(buttons.at(createButtonIndex)).toHaveProp("title", "Create");
+    expect(buttons.at(cancelButtonIndex)).toHaveProp("label", "Cancel");
+    expect(buttons.at(cancelButtonIndex)).toHaveProp("title", "Cancel");
   });
 
   it("NewProjectDialog calls back onCreate", async () => {
@@ -72,7 +73,7 @@ describe("Tests for NewProjectDialog component", () => {
 
     {
       const createButton = dialog.find("Button").at(createButtonIndex);
-      expect(createButton.prop("isDisabled")).toBeTruthy();
+      expect(createButton).toHaveProp("isDisabled", true);
     }
 
     await promiseWait(3); // wait on templates loading and md-to-html
@@ -80,7 +81,7 @@ describe("Tests for NewProjectDialog component", () => {
 
     {
       const createButton = dialog.find("Button").at(createButtonIndex);
-      expect(createButton.prop("isDisabled")).toBeFalsy();
+      expect(createButton).toHaveProp("isDisabled", false);
       createButton.simulate("click");
       expect(chosenTemplate).toBeTruthy();
     }

--- a/tests/components/Split/Split.spec.tsx
+++ b/tests/components/Split/Split.spec.tsx
@@ -1,6 +1,7 @@
 /* Any copyright is dedicated to the Public Domain.
  * http://creativecommons.org/publicdomain/zero/1.0/ */
 
+import "jest-enzyme";
 import * as React from "react";
 import {mount} from "enzyme";
 import {Split, SplitOrientation} from "../../../src/components/Split";
@@ -17,22 +18,22 @@ describe("Tests for Split", () => {
   it("should render correctly (horizontal)", () => {
     const wrapper = setup({ orientation: SplitOrientation.Horizontal });
     const split = wrapper.find(".split");
-    expect(split.prop("style")).toEqual({ flexDirection: "column" });
+    expect(split).toHaveStyle({ flexDirection: "column" });
     expect(split.children().length).toEqual(3);
-    expect(split.childAt(0).hasClass("split-pane")).toEqual(true);
-    expect(split.childAt(0).prop("style")).toEqual({ flexBasis: "0px" });
-    expect(split.childAt(0).childAt(0).hasClass("div0")).toEqual(true);
-    expect(split.childAt(1).prop("className")).toEqual("resizer horizontal");
-    expect(split.childAt(2).hasClass("split-pane")).toEqual(true);
-    expect(split.childAt(2).prop("style")).toEqual({ flex: 1 });
-    expect(split.childAt(2).childAt(0).hasClass("div1")).toEqual(true);
+    expect(split.childAt(0)).toHaveClassName("split-pane");
+    expect(split.childAt(0)).toHaveStyle({ flexBasis: "0px" });
+    expect(split.childAt(0).childAt(0)).toHaveClassName("div0");
+    expect(split.childAt(1)).toHaveProp("className", "resizer horizontal");
+    expect(split.childAt(2)).toHaveClassName("split-pane");
+    expect(split.childAt(2)).toHaveStyle({ flex: 1 });
+    expect(split.childAt(2).childAt(0)).toHaveClassName("div1");
     wrapper.unmount();
   });
   it("should render correctly (vertical)", () => {
     const wrapper = setup({ orientation: SplitOrientation.Vertical });
     const split = wrapper.find(".split");
-    expect(split.prop("style")).toEqual({ flexDirection: "row" });
-    expect(split.childAt(1).prop("className")).toEqual("resizer vertical");
+    expect(split).toHaveStyle({ flexDirection: "row" });
+    expect(split.childAt(1)).toHaveProp("className", "resizer vertical");
     wrapper.unmount();
   });
   it("should add event listeners for mousemove and mouseup events on mount", () => {

--- a/tests/components/StatusBar/StatusBar.spec.tsx
+++ b/tests/components/StatusBar/StatusBar.spec.tsx
@@ -1,6 +1,7 @@
 /* Any copyright is dedicated to the Public Domain.
  * http://creativecommons.org/publicdomain/zero/1.0/ */
 
+import "jest-enzyme";
 import * as React from "react";
 import {shallow} from "enzyme";
 import {StatusBar} from "../../../src/components/StatusBar";
@@ -16,18 +17,18 @@ describe("Tests for StatusBar", () => {
   });
   it("should render empty string if project has no status", () => {
     const wrapper = setup();
-    expect(wrapper.text()).toEqual("");
+    expect(wrapper).toHaveText("");
   });
   it("should not apply active className if project has no status", () => {
     const wrapper = setup();
-    expect(wrapper.find(".active")).toHaveLength(0);
+    expect(wrapper.find(".active")).not.toExist();
   });
   it("should update text and className on status change", () => {
     const project = appStore.getProject().getModel();
     const wrapper = setup();
     project.pushStatus("test");
     wrapper.update();
-    expect(wrapper.text()).toEqual("test");
-    expect(wrapper.find(".active")).toHaveLength(1);
+    expect(wrapper).toHaveText("test");
+    expect(wrapper.find(".active")).toExist();
   });
 });

--- a/tests/components/Tabs/Tab.spec.tsx
+++ b/tests/components/Tabs/Tab.spec.tsx
@@ -1,6 +1,7 @@
 /* Any copyright is dedicated to the Public Domain.
  * http://creativecommons.org/publicdomain/zero/1.0/ */
 
+import "jest-enzyme";
 import * as React from "react";
 import {shallow} from "enzyme";
 import {Tab} from "../../../src/components/editor/Tabs";
@@ -11,10 +12,10 @@ describe("Tests for Tabs.tsx/Tab", () => {
   };
   it("should render correctly", () => {
     const wrapper = setup({ label: "test", icon: "test" });
-    expect(wrapper.find(".tab").exists()).toEqual(true);
-    expect(wrapper.find(".monaco-icon-label").hasClass("test")).toEqual(true);
-    expect(wrapper.find(".label").text()).toEqual("test");
-    expect(wrapper.find(".close").exists()).toEqual(true);
+    expect(wrapper.find(".tab")).toExist();
+    expect(wrapper.find(".monaco-icon-label")).toHaveClassName("test");
+    expect(wrapper.find(".label")).toHaveText("test");
+    expect(wrapper.find(".close")).toExist();
   });
   it("should apply active classname if passed isActive prop", () => {
     const wrapper = setup({ isActive: true });
@@ -30,9 +31,9 @@ describe("Tests for Tabs.tsx/Tab", () => {
   });
   it("should ONLY apply active/marked/italic classname on props", () => {
     const wrapper = setup({});
-    expect(wrapper.find(".active").exists()).toEqual(false);
-    expect(wrapper.find(".marked").exists()).toEqual(false);
-    expect(wrapper.find(".italic").exists()).toEqual(false);
+    expect(wrapper.find(".active")).not.toExist();
+    expect(wrapper.find(".marked")).not.toExist();
+    expect(wrapper.find(".italic")).not.toExist();
   });
   it("should invoke onClose with value prop when clicking the close icon", () => {
     const onClose = jest.fn();

--- a/tests/components/Tabs/Tabs.spec.tsx
+++ b/tests/components/Tabs/Tabs.spec.tsx
@@ -1,6 +1,7 @@
 /* Any copyright is dedicated to the Public Domain.
  * http://creativecommons.org/publicdomain/zero/1.0/ */
 
+import "jest-enzyme";
 import * as React from "react";
 import {shallow, mount} from "enzyme";
 import {Button} from "../../../src/components/shared/Button";
@@ -25,10 +26,10 @@ describe("Tests for Tabs.tsx/Tabs", () => {
     const tabB = <Tab label="tabB" key={2} />;
     const button = <Button label="buttonA" />;
     const wrapper = setup({ children: [tabA, tabB], commands: button });
-    expect(wrapper.find(".tabs-container").exists()).toEqual(true);
-    expect(wrapper.find(".tabs-tab-container").find(Tab).at(0).prop("label")).toEqual("tabA");
-    expect(wrapper.find(".tabs-tab-container").find(Tab).at(1).prop("label")).toEqual("tabB");
-    expect(wrapper.find(".tabs-command-container").find(Button).at(0).prop("label")).toEqual("buttonA");
+    expect(wrapper.find(".tabs-container")).toExist();
+    expect(wrapper.find(".tabs-tab-container").find(Tab).at(0)).toHaveProp("label", "tabA");
+    expect(wrapper.find(".tabs-tab-container").find(Tab).at(1)).toHaveProp("label", "tabB");
+    expect(wrapper.find(".tabs-command-container").find(Button).at(0)).toHaveProp("label", "buttonA");
   });
   it("should invoke onDoubleClick when double clicking the tabs container", () => {
     const onDoubleClick = jest.fn();

--- a/tests/components/Toast/Toasts.spec.tsx
+++ b/tests/components/Toast/Toasts.spec.tsx
@@ -1,6 +1,7 @@
 /* Any copyright is dedicated to the Public Domain.
  * http://creativecommons.org/publicdomain/zero/1.0/ */
 
+import "jest-enzyme";
 import * as React from "react";
 import {shallow, mount} from "enzyme";
 import {ToastContainer, Toast} from "../../../src/components/Toasts";
@@ -23,11 +24,11 @@ describe("Tests for Toasts", () => {
     };
     const toast = shallow(<Toast {...props}/>);
     const button: ReactWrapper = toast.find(Button).last();
-    expect(button.props().label).toBe("Dismiss");
-    expect(button.props().title).toBe("Dismiss");
-    expect(button.props().customClassName).toBe("button-toast");
-    expect(button.props().icon).toEqual(<GoX />);
-    expect(button.props().onClick).toEqual(props.onDismiss);
+    expect(button).toHaveProp("label", "Dismiss");
+    expect(button).toHaveProp("title", "Dismiss");
+    expect(button).toHaveProp("customClassName", "button-toast");
+    expect(button).toHaveProp("icon", <GoX />);
+    expect(button).toHaveProp("onClick", props.onDismiss);
   });
   it("Render ToastContainer Component with Toasts", () => {
     const wrapper = setup();
@@ -36,7 +37,7 @@ describe("Tests for Toasts", () => {
       expect(wrapper.state().toasts.length).toBe(i);
       wrapper.update();	
       expect(wrapper.find(Toast)).toHaveLength(i);
-      expect(wrapper.find(Toast).at(i - 1).props().message).toEqual(message);
+      expect(wrapper.find(Toast).at(i - 1)).toHaveProp("message", message);
     }
   });
   it("Toast Dismiss", () => {

--- a/tests/components/ViewTabs/ViewTabs.spec.tsx
+++ b/tests/components/ViewTabs/ViewTabs.spec.tsx
@@ -1,6 +1,7 @@
 /* Any copyright is dedicated to the Public Domain.
  * http://creativecommons.org/publicdomain/zero/1.0/ */
 
+import "jest-enzyme";
 import * as React from "react";
 import {mount} from "enzyme";
 
@@ -86,32 +87,32 @@ describe("Tests for ViewTabs", () => {
     const saveButtonIndex = 1;
     const buttons = wrapper.find(Button);
     const tabs = wrapper.find(Tab);
-    expect(wrapper.find(".editor-pane-container").exists()).toEqual(true);
-    expect(wrapper.find(".blurred").exists()).toEqual(true);
+    expect(wrapper.find(".editor-pane-container")).toExist();
+    expect(wrapper.find(".blurred")).toExist();
     expect(wrapper.find(Tabs).length).toEqual(1);
     expect(wrapper.find(EditorView).length).toEqual(1);
     expect(buttons.at(splitButtonIndex).key()).toEqual("split");
-    expect(buttons.at(splitButtonIndex).prop("title")).toEqual("Split Editor");
-    expect(buttons.at(splitButtonIndex).find(GoBook).exists()).toEqual(true);
+    expect(buttons.at(splitButtonIndex)).toHaveProp("title", "Split Editor");
+    expect(buttons.at(splitButtonIndex).find(GoBook)).toExist();
     expect(buttons.at(saveButtonIndex).key()).toEqual("save");
-    expect(buttons.at(saveButtonIndex).prop("title")).toEqual("Save: CtrlCmd + S");
-    expect(buttons.at(saveButtonIndex).prop("label")).toEqual("Save");
-    expect(buttons.at(saveButtonIndex).prop("isDisabled")).toEqual(true);
-    expect(buttons.at(saveButtonIndex).find(GoClippy).exists()).toEqual(true);
-    expect(tabs.at(0).prop("isActive")).toEqual(true);
-    expect(tabs.at(0).prop("label")).toEqual("fileA");
-    expect(tabs.at(1).prop("isActive")).toEqual(false);
-    expect(tabs.at(1).prop("label")).toEqual("fileB");
+    expect(buttons.at(saveButtonIndex)).toHaveProp("title", "Save: CtrlCmd + S");
+    expect(buttons.at(saveButtonIndex)).toHaveProp("label", "Save");
+    expect(buttons.at(saveButtonIndex)).toHaveProp("isDisabled", true);
+    expect(buttons.at(saveButtonIndex).find(GoClippy)).toExist();
+    expect(tabs.at(0)).toHaveProp("isActive", true);
+    expect(tabs.at(0)).toHaveProp("label", "fileA");
+    expect(tabs.at(1)).toHaveProp("isActive", false);
+    expect(tabs.at(1)).toHaveProp("label", "fileB");
     wrapper.unmount();
   });
   it("should render correctly when active view does not contain a file", () => {
     const {wrapper} = setup({ simulateNoFile: true });
-    expect(wrapper.find(".editor-pane-container").hasClass("empty")).toEqual(true);
+    expect(wrapper.find(".editor-pane-container")).toHaveClassName("empty");
     wrapper.unmount();
   });
   it("should render empty div when active view is null", () => {
     const {wrapper} = setup({ simulateNoView: true });
-    expect(wrapper.html()).toEqual("<div></div>");
+    expect(wrapper).toHaveHTML("<div></div>");
     wrapper.unmount();
   });
   it("should render correctly when previewing markdown files", () => {
@@ -122,19 +123,19 @@ describe("Tests for ViewTabs", () => {
     const buttons = wrapper.find(Button);
     expect(wrapper.find(MarkdownView).length).toEqual(1);
     expect(buttons.at(toggleButtonIndex).key()).toEqual("toggle");
-    expect(buttons.at(toggleButtonIndex).prop("title")).toEqual("Edit Markdown");
-    expect(buttons.at(toggleButtonIndex).find(GoCode).exists()).toEqual(true);
+    expect(buttons.at(toggleButtonIndex)).toHaveProp("title", "Edit Markdown");
+    expect(buttons.at(toggleButtonIndex).find(GoCode)).toExist();
     expect(buttons.at(splitButtonIndex).key()).toEqual("split");
     expect(buttons.at(saveButtonIndex).key()).toEqual("save");
-    expect(wrapper.find(Tab).at(0).prop("label")).toEqual("Preview fileA");
+    expect(wrapper.find(Tab).at(0)).toHaveProp("label", "Preview fileA");
     wrapper.unmount();
   });
   it("should render correctly when editing markdown files", () => {
     const {wrapper} = setup({ fileType: FileType.Markdown, viewType: ViewType.Editor });
     expect(wrapper.find(EditorView).length).toEqual(1);
-    expect(wrapper.find(Button).at(0).prop("title")).toEqual("Preview Markdown");
-    expect(wrapper.find(Button).at(0).find(GoEye).exists()).toEqual(true);
-    expect(wrapper.find(Tab).at(0).prop("label")).toEqual("fileA");
+    expect(wrapper.find(Button).at(0)).toHaveProp("title", "Preview Markdown");
+    expect(wrapper.find(Button).at(0).find(GoEye)).toExist();
+    expect(wrapper.find(Tab).at(0)).toHaveProp("label", "fileA");
     wrapper.unmount();
   });
   it("should invoke onChangeViewType with new ViewType when clicking the toggle button (Markdown)", () => {
@@ -156,19 +157,19 @@ describe("Tests for ViewTabs", () => {
     const buttons = wrapper.find(Button);
     expect(wrapper.find(VizView).length).toEqual(1);
     expect(buttons.at(toggleButtonIndex).key()).toEqual("toggle");
-    expect(buttons.at(toggleButtonIndex).prop("title")).toEqual("Edit GraphViz DOT File");
-    expect(buttons.at(toggleButtonIndex).find(GoCode).exists()).toEqual(true);
+    expect(buttons.at(toggleButtonIndex)).toHaveProp("title", "Edit GraphViz DOT File");
+    expect(buttons.at(toggleButtonIndex).find(GoCode)).toExist();
     expect(buttons.at(splitButtonIndex).key()).toEqual("split");
     expect(buttons.at(saveButtonIndex).key()).toEqual("save");
-    expect(wrapper.find(Tab).at(0).prop("label")).toEqual("Preview fileA");
+    expect(wrapper.find(Tab).at(0)).toHaveProp("label", "Preview fileA");
     wrapper.unmount();
   });
   it("should render correctly when editing dot files", () => {
     const {wrapper} = setup({ fileType: FileType.DOT, viewType: ViewType.Editor });
     expect(wrapper.find(EditorView).length).toEqual(1);
-    expect(wrapper.find(Button).at(0).prop("title")).toEqual("Preview GraphViz DOT File");
-    expect(wrapper.find(Button).at(0).find(GoEye).exists()).toEqual(true);
-    expect(wrapper.find(Tab).at(0).prop("label")).toEqual("fileA");
+    expect(wrapper.find(Button).at(0)).toHaveProp("title", "Preview GraphViz DOT File");
+    expect(wrapper.find(Button).at(0).find(GoEye)).toExist();
+    expect(wrapper.find(Tab).at(0)).toHaveProp("label", "fileA");
     wrapper.unmount();
   });
   it("should invoke onChangeViewType with new ViewType when clicking the toggle button (DOT)", () => {
@@ -190,17 +191,17 @@ describe("Tests for ViewTabs", () => {
     expect(wrapper.find(BinaryView).length).toEqual(1);
     expect(buttons.at(splitButtonIndex).key()).toEqual("split");
     expect(buttons.at(saveButtonIndex).key()).toEqual("save");
-    expect(wrapper.find(Tab).at(0).prop("label")).toEqual("Binary fileA");
+    expect(wrapper.find(Tab).at(0)).toHaveProp("label", "Binary fileA");
     wrapper.unmount();
   });
   it("should render correctly when a tab is marked as a preview tab", () => {
     const {wrapper} = setup({ preview: true });
-    expect(wrapper.find(Tab).at(0).prop("isItalic")).toEqual(true);
+    expect(wrapper.find(Tab).at(0)).toHaveProp("isItalic", true);
     wrapper.unmount();
   });
   it("should NOT apply blurred classname if passing hasFocus prop", () => {
     const {wrapper} = setup({ hasFocus: true });
-    expect(wrapper.find(".blurred").exists()).toEqual(false);
+    expect(wrapper.find(".blurred")).not.toExist();
     wrapper.unmount();
   });
   it("should invoke onSplitViews when clicking the split button", () => {
@@ -214,7 +215,7 @@ describe("Tests for ViewTabs", () => {
   it("should save the open file when clicking the save button", () => {
     const {wrapper, getFile} = setup({ simulateDirtyFile: true });
     expect(getFile().isDirty).toEqual(true);
-    expect(wrapper.find(Button).at(1).prop("isDisabled")).toEqual(false);
+    expect(wrapper.find(Button).at(1)).toHaveProp("isDisabled", false);
     wrapper.find(Button).at(1).simulate("click");
     expect(getFile().isDirty).toEqual(false);
     wrapper.unmount();

--- a/tests/components/icons/icons.spec.tsx
+++ b/tests/components/icons/icons.spec.tsx
@@ -1,6 +1,7 @@
 /* Any copyright is dedicated to the Public Domain.
  * http://creativecommons.org/publicdomain/zero/1.0/ */
 
+import "jest-enzyme";
 import * as React from "react";
 import {shallow} from "enzyme";
 import {
@@ -39,7 +40,7 @@ describe("Tests for Icon component", () => {
   };
   it("Icon renders correctly", () => {
     const wrapper = setup({ src: "test" });
-    expect(wrapper.first().prop("style")).toEqual({
+    expect(wrapper.first()).toHaveStyle({
       width: 16,
       height: 16,
       backgroundImage: `url("test")`
@@ -47,132 +48,132 @@ describe("Tests for Icon component", () => {
   });
   it("GoRepoForked renders correctly", () => {
     const wrapper = shallow(<GoRepoForked/>);
-    expect(wrapper.first().hasClass("octicon")).toEqual(true);
-    expect(wrapper.first().hasClass("octicon-repo-forked")).toEqual(true);
+    expect(wrapper.first()).toHaveClassName("octicon");
+    expect(wrapper.first()).toHaveClassName("octicon-repo-forked");
   });
   it("GoBeaker renders correctly", () => {
     const wrapper = shallow(<GoBeaker/>);
-    expect(wrapper.first().hasClass("octicon")).toEqual(true);
-    expect(wrapper.first().hasClass("octicon-beaker")).toEqual(true);
+    expect(wrapper.first()).toHaveClassName("octicon");
+    expect(wrapper.first()).toHaveClassName("octicon-beaker");
   });
   it("GoGear renders correctly", () => {
     const wrapper = shallow(<GoGear/>);
-    expect(wrapper.first().hasClass("octicon")).toEqual(true);
-    expect(wrapper.first().hasClass("octicon-gear")).toEqual(true);
+    expect(wrapper.first()).toHaveClassName("octicon");
+    expect(wrapper.first()).toHaveClassName("octicon-gear");
   });
   it("GoBeakerGear renders correctly", () => {
     const wrapper = shallow(<GoBeakerGear/>);
-    expect(wrapper.first().hasClass("octicon")).toEqual(true);
-    expect(wrapper.first().hasClass("octicon-gear")).toEqual(true);
+    expect(wrapper.first()).toHaveClassName("octicon");
+    expect(wrapper.first()).toHaveClassName("octicon-gear");
   });
   it("GoRocket renders correctly", () => {
     const wrapper = shallow(<GoRocket/>);
-    expect(wrapper.first().hasClass("octicon")).toEqual(true);
-    expect(wrapper.first().hasClass("octicon-rocket")).toEqual(true);
+    expect(wrapper.first()).toHaveClassName("octicon");
+    expect(wrapper.first()).toHaveClassName("octicon-rocket");
   });
   it("GoPencil renders correctly", () => {
     const wrapper = shallow(<GoPencil/>);
-    expect(wrapper.first().hasClass("octicon")).toEqual(true);
-    expect(wrapper.first().hasClass("octicon-pencil")).toEqual(true);
+    expect(wrapper.first()).toHaveClassName("octicon");
+    expect(wrapper.first()).toHaveClassName("octicon-pencil");
   });
   it("GoDelete renders correctly", () => {
     const wrapper = shallow(<GoDelete/>);
-    expect(wrapper.first().hasClass("octicon")).toEqual(true);
-    expect(wrapper.first().hasClass("octicon-x")).toEqual(true);
+    expect(wrapper.first()).toHaveClassName("octicon");
+    expect(wrapper.first()).toHaveClassName("octicon-x");
   });
   it("GoVerified renders correctly", () => {
     const wrapper = shallow(<GoVerified/>);
-    expect(wrapper.first().hasClass("octicon")).toEqual(true);
-    expect(wrapper.first().hasClass("octicon-verified")).toEqual(true);
+    expect(wrapper.first()).toHaveClassName("octicon");
+    expect(wrapper.first()).toHaveClassName("octicon-verified");
   });
   it("GoFile renders correctly", () => {
     const wrapper = shallow(<GoFile/>);
-    expect(wrapper.first().hasClass("octicon")).toEqual(true);
-    expect(wrapper.first().hasClass("octicon-file")).toEqual(true);
+    expect(wrapper.first()).toHaveClassName("octicon");
+    expect(wrapper.first()).toHaveClassName("octicon-file");
   });
   it("GoFileBinary renders correctly", () => {
     const wrapper = shallow(<GoFileBinary/>);
-    expect(wrapper.first().hasClass("octicon")).toEqual(true);
-    expect(wrapper.first().hasClass("octicon-file-binary")).toEqual(true);
+    expect(wrapper.first()).toHaveClassName("octicon");
+    expect(wrapper.first()).toHaveClassName("octicon-file-binary");
   });
   it("GoFileCode renders correctly", () => {
     const wrapper = shallow(<GoFileCode/>);
-    expect(wrapper.first().hasClass("octicon")).toEqual(true);
-    expect(wrapper.first().hasClass("octicon-file-code")).toEqual(true);
+    expect(wrapper.first()).toHaveClassName("octicon");
+    expect(wrapper.first()).toHaveClassName("octicon-file-code");
   });
   it("GoQuote renders correctly", () => {
     const wrapper = shallow(<GoQuote/>);
-    expect(wrapper.first().hasClass("octicon")).toEqual(true);
-    expect(wrapper.first().hasClass("octicon-quote")).toEqual(true);
+    expect(wrapper.first()).toHaveClassName("octicon");
+    expect(wrapper.first()).toHaveClassName("octicon-quote");
   });
   it("GoDesktopDownload renders correctly", () => {
     const wrapper = shallow(<GoDesktopDownload/>);
-    expect(wrapper.first().hasClass("octicon")).toEqual(true);
-    expect(wrapper.first().hasClass("octicon-desktop-download")).toEqual(true);
+    expect(wrapper.first()).toHaveClassName("octicon");
+    expect(wrapper.first()).toHaveClassName("octicon-desktop-download");
   });
   it("GoX renders correctly", () => {
     const wrapper = shallow(<GoX/>);
-    expect(wrapper.first().hasClass("octicon")).toEqual(true);
-    expect(wrapper.first().hasClass("octicon-x")).toEqual(true);
+    expect(wrapper.first()).toHaveClassName("octicon");
+    expect(wrapper.first()).toHaveClassName("octicon-x");
   });
   it("GoKebabHorizontal renders correctly", () => {
     const wrapper = shallow(<GoKebabHorizontal/>);
-    expect(wrapper.first().hasClass("octicon")).toEqual(true);
-    expect(wrapper.first().hasClass("octicon-kebab-horizontal")).toEqual(true);
+    expect(wrapper.first()).toHaveClassName("octicon");
+    expect(wrapper.first()).toHaveClassName("octicon-kebab-horizontal");
   });
   it("GoThreeBars renders correctly", () => {
     const wrapper = shallow(<GoThreeBars/>);
-    expect(wrapper.first().hasClass("octicon")).toEqual(true);
-    expect(wrapper.first().hasClass("octicon-three-bars")).toEqual(true);
+    expect(wrapper.first()).toHaveClassName("octicon");
+    expect(wrapper.first()).toHaveClassName("octicon-three-bars");
   });
   it("GoBook renders correctly", () => {
     const wrapper = shallow(<GoBook/>);
-    expect(wrapper.first().hasClass("octicon")).toEqual(true);
-    expect(wrapper.first().hasClass("octicon-book")).toEqual(true);
+    expect(wrapper.first()).toHaveClassName("octicon");
+    expect(wrapper.first()).toHaveClassName("octicon-book");
   });
   it("GoGist renders correctly", () => {
     const wrapper = shallow(<GoGist/>);
-    expect(wrapper.first().hasClass("octicon")).toEqual(true);
-    expect(wrapper.first().hasClass("octicon-gist")).toEqual(true);
+    expect(wrapper.first()).toHaveClassName("octicon");
+    expect(wrapper.first()).toHaveClassName("octicon-gist");
   });
   it("GoCheck renders correctly", () => {
     const wrapper = shallow(<GoCheck/>);
-    expect(wrapper.first().hasClass("octicon")).toEqual(true);
-    expect(wrapper.first().hasClass("octicon-check")).toEqual(true);
+    expect(wrapper.first()).toHaveClassName("octicon");
+    expect(wrapper.first()).toHaveClassName("octicon-check");
   });
   it("GoOpenIssue renders correctly", () => {
     const wrapper = shallow(<GoOpenIssue/>);
-    expect(wrapper.first().hasClass("octicon")).toEqual(true);
-    expect(wrapper.first().hasClass("octicon-issue-opened")).toEqual(true);
+    expect(wrapper.first()).toHaveClassName("octicon");
+    expect(wrapper.first()).toHaveClassName("octicon-issue-opened");
   });
   it("GoFileDirectory renders correctly", () => {
     const wrapper = shallow(<GoFileDirectory/>);
-    expect(wrapper.first().hasClass("octicon")).toEqual(true);
-    expect(wrapper.first().hasClass("octicon-file-directory")).toEqual(true);
+    expect(wrapper.first()).toHaveClassName("octicon");
+    expect(wrapper.first()).toHaveClassName("octicon-file-directory");
   });
   it("GoQuestion renders correctly", () => {
     const wrapper = shallow(<GoQuestion/>);
-    expect(wrapper.first().hasClass("octicon")).toEqual(true);
-    expect(wrapper.first().hasClass("octicon-question")).toEqual(true);
+    expect(wrapper.first()).toHaveClassName("octicon");
+    expect(wrapper.first()).toHaveClassName("octicon-question");
   });
   it("GoClippy renders correctly", () => {
     const wrapper = shallow(<GoClippy/>);
-    expect(wrapper.first().hasClass("octicon")).toEqual(true);
-    expect(wrapper.first().hasClass("octicon-clippy")).toEqual(true);
+    expect(wrapper.first()).toHaveClassName("octicon");
+    expect(wrapper.first()).toHaveClassName("octicon-clippy");
   });
   it("GoEye renders correctly", () => {
     const wrapper = shallow(<GoEye/>);
-    expect(wrapper.first().hasClass("octicon")).toEqual(true);
-    expect(wrapper.first().hasClass("octicon-eye")).toEqual(true);
+    expect(wrapper.first()).toHaveClassName("octicon");
+    expect(wrapper.first()).toHaveClassName("octicon-eye");
   });
   it("GoCode renders correctly", () => {
     const wrapper = shallow(<GoCode/>);
-    expect(wrapper.first().hasClass("octicon")).toEqual(true);
-    expect(wrapper.first().hasClass("octicon-code")).toEqual(true);
+    expect(wrapper.first()).toHaveClassName("octicon");
+    expect(wrapper.first()).toHaveClassName("octicon-code");
   });
   it("GoCloudUpload renders correctly", () => {
     const wrapper = shallow(<GoCloudUpload/>);
-    expect(wrapper.first().hasClass("octicon")).toEqual(true);
-    expect(wrapper.first().hasClass("octicon-cloud-upload")).toEqual(true);
+    expect(wrapper.first()).toHaveClassName("octicon");
+    expect(wrapper.first()).toHaveClassName("octicon-cloud-upload");
   });
 });


### PR DESCRIPTION
The idea is that this will make the tests easier to read/understand and yield better error messages when failing. 

For example:
```js
expect(button).toHaveClassName("button");
// Error message:
// Expected <div> to have className of ".button" but instead found "file-button"
```
Instead of how it currently looks:
```js
expect(button.hasClass("button")).toEqual(true);
// Error message:
// Expected value to equal: true
// Received: false
```


### Summary of Changes
* Improving assertions for a number of component tests using jest-enzyme