### PR TITLE
Fixing issue that makes it impossible to move file/folder

### DIFF
--- a/src/components/DirectoryTree.tsx
+++ b/src/components/DirectoryTree.tsx
@@ -286,8 +286,8 @@ export class DirectoryTree extends React.Component<DirectoryTreeProps, {
           const items = Array.from(originalEvent.browserEvent.dataTransfer.items);
           // In Firefox, tree elements get data transfer items with the "text/uri-list" type. This is a
           // workaround to ignore that behavior.
-          const hasItemsUriListType = !items.some(item => item.type === "text/uri-list");
-          if (items.length && hasItemsUriListType) {
+          const hasItemsUriListType = items.some(item => item.type === "text/uri-list");
+          if (items.length && !hasItemsUriListType) {
             return {
               accept: items.every(item => isUploadAllowedForMimeType(item.type)),
               bubble: DragOverBubble.BUBBLE_DOWN,

--- a/src/util.ts
+++ b/src/util.ts
@@ -19,7 +19,7 @@
  * SOFTWARE.
  */
 
-import { fileTypeForExtension, isBinaryFileType, Directory } from "./model";
+import { fileTypeForExtension, isBinaryFileType, Directory, FileType, fileTypeForMimeType } from "./model";
 
 export function toAddress(n: number) {
   let s = n.toString(16);
@@ -239,4 +239,11 @@ export async function uploadFilesToDirectory(files: FileList, root: Directory) {
       console.log("Unable to read the file!");
     }
   });
+}
+
+export function isUploadAllowedForMimeType(type: string) {
+  if (type === "") { // Firefox doesn't show the "application/wasm" mime type.
+    return true;
+  }
+  return fileTypeForMimeType(type) !== FileType.Unknown;
 }


### PR DESCRIPTION
It seems like its currently not possible to move files/folders around in the directory tree. This is blocked somewhere around [here](https://github.com/wasdk/WebAssemblyStudio/blob/1c3104cf4c781a3480360f0e2239241a61b11bb5/src/components/DirectoryTree.tsx#L283). This PR adds a check to allow both drag and drop uploads and regular move actions.

### Summary of Changes
* Checking whether or not the drag data contains any elements (In other words - is it a file dragged from outside the browser or is it an element being moved?)

### Test Plan
- Create empty C project
- Verify that files in the directory tree can be dragged/dropped
- Verify that files can be uploaded via drag n drop
- Verify that this works in Firefox as well
