### PR TITLE
Ignoring Typescript declaration files when running mutation testing

### DIFF
--- a/stryker.conf.js
+++ b/stryker.conf.js
@@ -9,7 +9,10 @@ module.exports = function(config) {
       baseDir: "mutation/html",
     },
     coverageAnalysis: "off",
-    mutate: ["src/**/*.ts?(x)"],
+    mutate: [
+      "src/**/*.ts?(x)",
+      "!src/**/**.d.ts"
+    ],
     timeoutMs: 60000
   });
 };


### PR DESCRIPTION
Ignoring Typescript declaration files when running mutation testing

### Summary of Changes
* Updating stryker.conf.js
