### PR TITLE
Listen to onDidChangeProblems in ControlCenter.tsx

### DIFF
--- a/src/components/ControlCenter.tsx
+++ b/src/components/ControlCenter.tsx
@@ -48,6 +48,11 @@ export class ControlCenter extends React.Component<{
     problemCount: number;
     outputLineCount: number;
   }> {
+  outputView: View;
+  refs: { container: HTMLDivElement };
+  outputViewEditor: EditorView;
+  updateOutputViewTimeout: any;
+
   constructor(props: any) {
     super(props);
     const outputFile = appStore.getOutput().getModel();
@@ -66,21 +71,20 @@ export class ControlCenter extends React.Component<{
   onOutputChanged = () => {
     this.updateOutputView();
   }
+  onDidChangeProblems = () => {
+    this.updateOutputView();
+  }
   componentDidMount() {
     appStore.onOutputChanged.register(this.onOutputChanged);
+    appStore.onDidChangeProblems.register(this.onDidChangeProblems);
   }
   componentWillUnmount() {
     appStore.onOutputChanged.unregister(this.onOutputChanged);
+    appStore.onDidChangeProblems.unregister(this.onDidChangeProblems);
   }
-  outputView: View;
-  refs: {
-    container: HTMLDivElement;
-  };
-  outputViewEditor: EditorView;
   setOutputViewEditor(editor: EditorView) {
     this.outputViewEditor = editor;
   }
-  updateOutputViewTimeout: any;
   updateOutputView() {
     if (!this.updateOutputViewTimeout) {
       this.updateOutputViewTimeout = window.setTimeout(() => {


### PR DESCRIPTION
The Problems tab in the ControlCenter does not update on new problems (in other words, it gives no indication that there is a problem). This PR fixes this by registering a listener for onDidChangeProblems events when the ControlCenter component mounts.

### Summary of Changes
* Listen to onDidChangeProblems in ControlCenter.tsx

### Test Plan
- Create empty C project
- Open main.c
- Change 42 to a string
- Save 
- Build
- The Problems tab should now indicate that there is one problem
