### PR TITLE
Fixes issue #291

### DIFF
--- a/src/utils/Template.ts
+++ b/src/utils/Template.ts
@@ -82,6 +82,7 @@ export class FileTemplate extends Template {
       case FileType.Wat: icon = "wat-lang-file-icon"; break;
     }
     if (file instanceof Directory) {
+      this.monacoIconLabel.classList.remove("file-icon");
       this.monacoIconLabel.classList.add("folder-icon");
     } else {
       this.monacoIconLabel.classList.add("file-icon");

--- a/tests/unit/Template.spec.ts
+++ b/tests/unit/Template.spec.ts
@@ -73,6 +73,7 @@ describe("Tests for Template", () => {
       const directory = new Directory("src");
       template.set(directory);
       expect(template.monacoIconLabel.classList.contains("folder-icon")).toEqual(true);
+      expect(template.monacoIconLabel.classList.contains("file-icon")).toEqual(false);
     });
     it("should handle dirty files", () => {
       const container = document.createElement("div");


### PR DESCRIPTION
Associated Issue: #291

### Summary of Changes
* Removing the "file-icon" class name (which may have been applied somehow during the move) if the file is a directory.

### Test Plan
- Create empty C project
- Create a new directory
- Drag package.json into src
- Drag package.json into your new directory
- Drag your new directory into src
- Drag your new directory back into root
- Your new folder should no longer receive icon from the file (package.json)
