### PR TITLE
Limiting the amount of actions in upload file/dir dialog

### DIFF
--- a/src/components/DirectoryTree.tsx
+++ b/src/components/DirectoryTree.tsx
@@ -42,6 +42,7 @@ export interface DirectoryTreeProps {
   onDoubleClickFile?: (file: File) => void;
   onUploadFile?: (directory: Directory) => void;
   onCreateGist?: (fileOrDirectory: File) => void;
+  onlyUploadActions?: boolean;
 }
 
 export class DirectoryTree extends React.Component<DirectoryTreeProps, {
@@ -149,6 +150,20 @@ export class DirectoryTree extends React.Component<DirectoryTreeProps, {
   }
   getActions(file: File, event: ContextMenuEvent) {
     const actions: any[] = [];
+
+    // Upload options (Limited to delete & edit)
+    if (this.props.onlyUploadActions) {
+      if (!file.parent) {
+        return actions;
+      }
+      this.props.onDeleteFile && actions.push(new MonacoUtils.Action("x", "Delete", "octicon-x", true, () => {
+        return this.props.onDeleteFile(file as Directory);
+      }));
+      this.props.onEditFile && actions.push(new MonacoUtils.Action("x", "Edit", "octicon-pencil", true, () => {
+        return this.props.onEditFile(file as Directory);
+      }));
+      return actions;
+    }
 
     // Directory options
     if (file instanceof Directory) {

--- a/src/components/UploadFileDialog.tsx
+++ b/src/components/UploadFileDialog.tsx
@@ -28,6 +28,8 @@ import { File, Directory, ModelRef } from "../model";
 import { UploadInput } from "./Widgets";
 import { DirectoryTree } from "./DirectoryTree";
 import { uploadFilesToDirectory } from "../util";
+import { EditFileDialog } from "./EditFileDialog";
+import { updateFileNameAndDescription } from "../actions/AppActions";
 
 export interface UploadFileDialogProps {
   isOpen: boolean;
@@ -38,6 +40,7 @@ export interface UploadFileDialogProps {
 
 export interface UploadFileDialogState {
   hasFilesToUpload: boolean;
+  editFileDialogFile?: ModelRef<File>;
 }
 
 export class UploadFileDialog extends React.Component<UploadFileDialogProps, UploadFileDialogState> {
@@ -64,6 +67,20 @@ export class UploadFileDialog extends React.Component<UploadFileDialogProps, Upl
       overlayClassName="overlay"
       ariaHideApp={false}
     >
+      {this.state.editFileDialogFile &&
+        <EditFileDialog
+          isOpen={true}
+          file={this.state.editFileDialogFile}
+          onCancel={() => {
+            this.setState({ editFileDialogFile: null });
+          }}
+          onChange={(name: string, description) => {
+            const file = this.state.editFileDialogFile.getModel();
+            updateFileNameAndDescription(file, name, description);
+            this.setState({ editFileDialogFile: null });
+          }}
+        />
+      }
       <div style={{ display: "flex", flexDirection: "column", height: "100%" }}>
         <div className="modal-title-bar">
           Upload Files & Directories to {this.props.directory.getModel().getPath()}
@@ -79,9 +96,13 @@ export class UploadFileDialog extends React.Component<UploadFileDialogProps, Upl
           </div>
           <div className="column" style={{height: "290px"}}>
             <DirectoryTree
+              onlyUploadActions={true}
               directory={this.root}
               onDeleteFile={(file: File) => {
                 file.parent.removeFile(file);
+              }}
+              onEditFile={(file: File) => {
+                this.setState({ editFileDialogFile: ModelRef.getRef(file) });
               }}
             />
           </div>


### PR DESCRIPTION
Associated Issue: #288 

### Summary of Changes
* Added a new prop to DirectoryTree.tsx (makes it possible to only show upload related actions)
* Updated UploadFileDialog.tsx (passing the new prop and adding edit file functionality)
* Added two test cases

### Test Plan
- Create C "hello, world" project
- Open the upload dialog
- Upload some files
- Verify that you now only see the "edit" and "delete" actions when opening the context menu
