### PR TITLE
Fix bug in Split.tsx: Should not be in a dragging state

### DIFF
--- a/src/components/Split.tsx
+++ b/src/components/Split.tsx
@@ -76,6 +76,7 @@ export class Split extends React.Component<SplitProps, {
   }
 
   componentWillReceiveProps(nextProps: SplitProps) {
+    this.onResizerMouseUp();
     const splits = this.canonicalizeSplits(nextProps);
     this.setupSolver(splits, this.getContainerSize(nextProps.orientation));
     this.querySolver(splits);
@@ -97,7 +98,7 @@ export class Split extends React.Component<SplitProps, {
   /**
    * This fires for all splits, even if the resizer doesn't belong to this split.
    */
-  onResizerMouseUp = (e: Event) => {
+  onResizerMouseUp = () => {
     if (this.index < 0) {
       return;
     }

--- a/tests/components/Split/Split.spec.tsx
+++ b/tests/components/Split/Split.spec.tsx
@@ -108,6 +108,17 @@ describe("Tests for Split", () => {
     expect(preventDefault).not.toHaveBeenCalled();
     wrapper.unmount();
   });
+  it("should abort any ongoing drag when receiving new props", () => {
+    const onChange = jest.fn();
+    const wrapper = setup({ orientation: SplitOrientation.Horizontal, onChange });
+    const instance = wrapper.instance() as Split;
+    wrapper.find(".resizer").simulate("mousedown");
+    wrapper.setProps({});
+    expect(instance.index).toEqual(-1);
+    expect(window.document.documentElement.style.pointerEvents).toEqual("auto");
+    expect(onChange).toHaveBeenCalled();
+    wrapper.unmount();
+  });
   /*
     TODO: Add tests to verify the actual solving after #184 is done
   */


### PR DESCRIPTION
Associated Issue: #283

### Summary of Changes
* Aborting any ongoing drag when the Split component receives new props
* Adding a test case

### Test Plan
- Create C "hello, world" project
- Drag a split
- Build the project (cmd + b) while still dragging the split
- It should no longer throw an error as described in #283