### PR TITLE
Implementing drag and drop upload of directories

### DIFF
--- a/src/components/UploadFileDialog.tsx
+++ b/src/components/UploadFileDialog.tsx
@@ -29,7 +29,7 @@ import { UploadInput } from "./Widgets";
 import { DirectoryTree } from "./DirectoryTree";
 import { uploadFilesToDirectory } from "../util";
 import { EditFileDialog } from "./EditFileDialog";
-import { updateFileNameAndDescription } from "../actions/AppActions";
+import { updateFileNameAndDescription, addFileTo } from "../actions/AppActions";
 
 export interface UploadFileDialogProps {
   isOpen: boolean;
@@ -52,8 +52,8 @@ export class UploadFileDialog extends React.Component<UploadFileDialogProps, Upl
     this.root.getModel().onDidChangeChildren.register(() => this.onRootChildrenChange());
     this.state = { hasFilesToUpload: false };
   }
-  private async handleUpload(files: FileList) {
-    await uploadFilesToDirectory(files, this.root.getModel());
+  private async handleUpload(items: DataTransferItemList) {
+    await uploadFilesToDirectory(items, this.root.getModel());
   }
   private onRootChildrenChange() {
     this.setState({ hasFilesToUpload: this.root.getModel().hasChildren() });
@@ -90,7 +90,7 @@ export class UploadFileDialog extends React.Component<UploadFileDialogProps, Upl
             <UploadInput
               ref={(ref) => this.uploadInput = ref}
               onChange={(e) => {
-                this.handleUpload(e.target.files);
+                this.handleUpload(e.target.items);
               }}
             />
           </div>
@@ -103,6 +103,9 @@ export class UploadFileDialog extends React.Component<UploadFileDialogProps, Upl
               }}
               onEditFile={(file: File) => {
                 this.setState({ editFileDialogFile: ModelRef.getRef(file) });
+              }}
+              onMoveFile={(file: File, directory: Directory) => {
+                addFileTo(file, directory);
               }}
             />
           </div>

--- a/src/monaco-dnd.ts
+++ b/src/monaco-dnd.ts
@@ -94,9 +94,9 @@ export class DragAndDrop implements IDragAndDrop {
    * Handles the action of dropping sources into target.
    */
   async drop(tree: ITree, data: IDragAndDropData, targetElement: File, originalEvent: DragMouseEvent) {
-    const files = originalEvent.browserEvent.dataTransfer.files;
-    if (files.length) {
-      await uploadFilesToDirectory(files, targetElement as Directory);
+    const items = originalEvent.browserEvent.dataTransfer.items;
+    if (!(data as any).elements && items.length) {
+      await uploadFilesToDirectory(items, targetElement as Directory);
       return;
     }
     const file: File = (data.getData() as any)[0];

--- a/tests/components/UploadFileDialog/UploadFileDialog.spec.tsx
+++ b/tests/components/UploadFileDialog/UploadFileDialog.spec.tsx
@@ -179,8 +179,8 @@ describe("Tests for UploadFileDialog", () => {
     const uploadFilesToDirectory = jest.spyOn(utils, "uploadFilesToDirectory");
     const { wrapper, addDirectory } = setup();
     const { root } = addDirectory("src");
-    const files = [];
-    wrapper.find(UploadInput).simulate("change", { target: { files }});
-    expect(uploadFilesToDirectory).toHaveBeenCalledWith(files, root.getModel());
+    const items = [];
+    wrapper.find(UploadInput).simulate("change", { target: { items }});
+    expect(uploadFilesToDirectory).toHaveBeenCalledWith(items, root.getModel());
   });
 });

--- a/tests/unit/DragAndDrop.spec.ts
+++ b/tests/unit/DragAndDrop.spec.ts
@@ -151,12 +151,12 @@ describe("Tests for DragAndDrop", () => {
       const dnd = new DragAndDrop({});
       const data = {} as any;
       const targetElement = {} as any;
-      const files = [{name: "file"}];
-      const originalEvent = { browserEvent: { dataTransfer: { files }}} as any;
+      const items = [{name: "file"}];
+      const originalEvent = { browserEvent: { dataTransfer: { items }}} as any;
       const uploadFilesToDirectory = jest.spyOn(utils, "uploadFilesToDirectory");
       uploadFilesToDirectory.mockImplementation(() => {});
       dnd.drop(null, data, targetElement, originalEvent);
-      expect(uploadFilesToDirectory).toHaveBeenCalledWith(files, targetElement);
+      expect(uploadFilesToDirectory).toHaveBeenCalledWith(items, targetElement);
     });
     it("should handle regular element drops", () => {
       const target = { props: { onMoveFile: jest.fn() }};
@@ -164,7 +164,7 @@ describe("Tests for DragAndDrop", () => {
       const file = new File("file", FileType.JavaScript);
       const data = { getData: () => [file] } as any;
       const targetElement = {} as any;
-      const originalEvent = { browserEvent: { dataTransfer: { files: [] }}} as any;
+      const originalEvent = { browserEvent: { dataTransfer: { items: [] }}} as any;
       dnd.drop(null, data, targetElement, originalEvent);
       expect(target.props.onMoveFile).toHaveBeenCalledWith(file, targetElement);
     });


### PR DESCRIPTION
Associated Issue: #131

### Summary of Changes
* Using DataTransferItemList (dataTransfer.items) instead of FileList (dataTransfer.files)
* Adding a function to recursively read an uploaded directory

### Test Plan
- Open the upload file/dir dialog
- Upload a folder via drag and drop
- Verify that this works in both Firefox and Chrome
- It should now also be possible to move files around in the upload file/dir dialog
