### PR TITLE
Ignoring .DS_Store files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ coverage
 mutation
 .stryker-tmp
 stats
+.DS_Store


### PR DESCRIPTION
Just to make life a bit easier for anyone else on mac.

### Summary of Changes
* Ignoring .DS_Store files in .gitignore