### PR TITLE
Update AssemblyScript template

### DIFF
--- a/templates/empty_ts/assembly/main.ts
+++ b/templates/empty_ts/assembly/main.ts
@@ -1,7 +1,15 @@
+@external("env", "sayHello")
 declare function sayHello(): void;
+
+declare namespace console {
+  function logi(value: i32): void;
+  function logf(value: f64): void;
+}
 
 sayHello();
 
 export function add(x: i32, y: i32): i32 {
   return x + y;
 }
+
+console.logi(add(1, 2));

--- a/templates/empty_ts/src/main.js
+++ b/templates/empty_ts/src/main.js
@@ -1,15 +1,15 @@
 WebAssembly.instantiateStreaming(fetch("../out/main.wasm"), {
   env: {
-    sayHello: function () {
+    sayHello() {
       console.log("Hello from WebAssembly!");
     },
-    abort: function (msg, file, line, column) {
+    abort(msg, file, line, column) {
       console.error("abort called at main.ts:" + line + ":" + column);
     }
   },
   console: {
-    logi: function (value) { console.log('logi: ' + value); },
-    logf: function (value) { console.log('logf: ' + value); }
+    logi(value) { console.log('logi: ' + value); },
+    logf(value) { console.log('logf: ' + value); }
   }
 }).then(result => {
   const exports = result.instance.exports;

--- a/templates/empty_ts/src/main.js
+++ b/templates/empty_ts/src/main.js
@@ -1,14 +1,17 @@
 WebAssembly.instantiateStreaming(fetch("../out/main.wasm"), {
   env: {
-    sayHello: function() {
+    sayHello: function () {
       console.log("Hello from WebAssembly!");
     },
-    abort: function(msg, file, line, column) {
+    abort: function (msg, file, line, column) {
       console.error("abort called at main.ts:" + line + ":" + column);
     }
+  },
+  console: {
+    logi: function (value) { console.log('logi: ' + value); },
+    logf: function (value) { console.log('logf: ' + value); }
   }
 }).then(result => {
   const exports = result.instance.exports;
   document.getElementById("container").innerText = "Result: " + exports.add(19, 23);
 }).catch(console.error);
-


### PR DESCRIPTION
AssemblyScript changed behaviour for default externals which was under "env" by default. For now it inherit it from filename if namespace or `@external` decorator not specified.

### Summary of Changes

* Update and fix _assembly/main.ts_ for provide right access to external imports.
* Add `logi` and `logf` under `console` namespace.
