### PR TITLE
Hiding the context menu if no actions are provided

### DIFF
--- a/src/monaco-controller.ts
+++ b/src/monaco-controller.ts
@@ -29,6 +29,9 @@ export function getController(target: any, getActionsFn?: Function, resolveMenuH
       const anchorOffset = { x: -10, y: -3 };
       const anchor = { x: event.posx + anchorOffset.x, y: event.posy + anchorOffset.y };
       const actions = getActionsFn && getActionsFn(file, event);
+      if (!actions || !actions.length) {
+        return false;
+      }
       target.contextMenuService.showContextMenu({
         getAnchor: () => anchor,
         getActions: () => monaco.Promise.as(actions || []),

--- a/tests/unit/Controller.spec.ts
+++ b/tests/unit/Controller.spec.ts
@@ -27,7 +27,7 @@ describe("Tests for Controller", () => {
   const setup = (resolveMenuPosition?, customEvent?) => {
     (window as any).innerHeight = 1200;
     const target = { contextMenuService: { showContextMenu: jest.fn() }};
-    const getActionsFn = jest.fn();
+    const getActionsFn = jest.fn().mockImplementation(() => ["action1"]);
     const tree = { setFocus: jest.fn(), DOMFocus: jest.fn() } as any;
     const file = new File("fileA", FileType.JavaScript);
     const event = customEvent || { posx: 10, posy: 10} as any;
@@ -59,6 +59,22 @@ describe("Tests for Controller", () => {
       controller.onContextMenu(tree, file, event);
       expect(getActionsFn).toHaveBeenCalledWith(file, event);
     });
+    it("should hide the context menu if no actions are provided", () => {
+      superOnContextMenu.mockClear();
+      const { controller, target, tree, file, event, getActionsFn } = setup();
+      getActionsFn.mockImplementation(() => undefined);
+      expect(controller.onContextMenu(tree, file, event)).toEqual(false);
+      expect(target.contextMenuService.showContextMenu).not.toHaveBeenCalled();
+      expect(superOnContextMenu).not.toHaveBeenCalled();
+    });
+    it("should hide the context menu if an empty array of actions are provided", () => {
+      superOnContextMenu.mockClear();
+      const { controller, target, tree, file, event, getActionsFn } = setup();
+      getActionsFn.mockImplementation(() => []);
+      expect(controller.onContextMenu(tree, file, event)).toEqual(false);
+      expect(target.contextMenuService.showContextMenu).not.toHaveBeenCalled();
+      expect(superOnContextMenu).not.toHaveBeenCalled();
+    });
     it("should call the contextMenuService", async () => {
       const { controller, target, tree, file, event } = setup();
       tree.DOMFocus.mockClear();
@@ -69,9 +85,10 @@ describe("Tests for Controller", () => {
       expect(options.onHide()).toBeUndefined();
       expect(options.onHide(true)).toBeUndefined();
       expect(tree.DOMFocus).toHaveBeenCalledTimes(1);
-      await expect(options.getActions()).resolves.toEqual([]);
+      await expect(options.getActions()).resolves.toEqual(["action1"]);
     });
     it("should call super.onContextMenu", () => {
+      superOnContextMenu.mockClear();
       const { controller, tree, file, event } = setup();
       controller.onContextMenu(tree, file, event);
       expect(superOnContextMenu).toHaveBeenCalledWith(tree, file, event);


### PR DESCRIPTION
Associated Issue: #301

### Summary of Changes
* Hiding the context menu if no actions are provided (in src/monaco-controller.ts)
* Updating/adding tests

### Test Plan
- Open the Problems view
- Right click to open the context menu
- You should no longer get an empty context menu (as shown in #301)