### PR TITLE
Improving the handling of name collisions

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -681,7 +681,6 @@ export class App extends React.Component<AppProps, AppState> {
             this.setState({ uploadFileDialogDirectory: null });
           }}
           onUpload={(files: File[]) => {
-            // TODO: Handle file collisions.
             files.map((file: File) => {
               addFileTo(file, this.state.uploadFileDialogDirectory.getModel());
             });

--- a/src/monaco-dnd.ts
+++ b/src/monaco-dnd.ts
@@ -83,8 +83,7 @@ export class DragAndDrop implements IDragAndDrop {
     return {
       accept: targetElement instanceof Directory &&
               targetElement !== file &&
-              !targetElement.isDescendantOf(file) &&
-              !targetElement.getImmediateChild(file.name),
+              !targetElement.isDescendantOf(file),
       bubble: DragOverBubble.BUBBLE_DOWN,
       autoExpand: true
     };

--- a/tests/unit/DragAndDrop.spec.ts
+++ b/tests/unit/DragAndDrop.spec.ts
@@ -102,21 +102,6 @@ describe("Tests for DragAndDrop", () => {
         autoExpand: true
       });
     });
-    it("should disable drop on name collisions", () => {
-      const dnd = new DragAndDrop({});
-      const file = new File("file", FileType.JavaScript);
-      const data = {
-        elements: [file],
-        getData: () => [file]
-      } as any;
-      const targetElement = new Directory("src");
-      targetElement.addFile(file);
-      expect(dnd.onDragOver(null, data, targetElement, null)).toEqual({
-        accept: false,
-        bubble: DragOverBubble.BUBBLE_DOWN,
-        autoExpand: true
-      });
-    });
     it("should disable drop when a folder is being moved into its own child", () => {
       const dnd = new DragAndDrop({});
       const parent = new Directory("parent");

--- a/tests/unit/directory.spec.ts
+++ b/tests/unit/directory.spec.ts
@@ -81,6 +81,26 @@ describe("Directory tests", () => {
       expect(callback.mock.calls[0][0]).toBe(c);
     });
   });
+  describe("handleNameCollision", () => {
+    it("should handle name collisions for file names", () => {
+      const directory = new Directory("src");
+      const fileA = directory.newFile("file.js", FileType.JavaScript);
+      const fileB = directory.newFile("file.js", FileType.JavaScript);
+      const fileC = new File("file.js", FileType.JavaScript);
+      expect(fileB.name).toEqual("file.2.js");
+      expect(directory.handleNameCollision(fileC.name)).toEqual("file.3.js");
+    });
+    it("should handle name collisions for directory names", () => {
+      const root = new Directory("src");
+      const dirA = root.newDirectory("dir");
+      const dirB = new Directory("dir");
+      expect(root.handleNameCollision(dirB.name, true)).toEqual("dir2");
+    });
+    it("should throw an error if name collision was not handled", () => {
+      const root = new Directory("src");
+      expect(() => root.handleNameCollision("test")).toThrowError("Name collision not handled");
+    });
+  });
   describe("addFile", () => {
     it("should add the file", () => {
       const file = new File("file", FileType.JavaScript);
@@ -96,13 +116,6 @@ describe("Directory tests", () => {
       directoryA.addFile(file);
       expect(() => directoryB.addFile(file)).toThrowError();
     });
-    it("should assert that there isn't already a file with the same name", () => {
-      const fileA = new File("file", FileType.JavaScript);
-      const fileB = new File("file", FileType.JavaScript);
-      const directory = new Directory("src");
-      directory.addFile(fileA);
-      expect(() => directory.addFile(fileB)).toThrowError();
-    });
     it("should dispatch an onDidChangeChildren event", () => {
       const file = new File("file", FileType.JavaScript);
       const directory = new Directory("src");
@@ -110,6 +123,17 @@ describe("Directory tests", () => {
       directory.onDidChangeChildren.register(callback);
       directory.addFile(file);
       expect(callback).toHaveBeenCalled();
+    });
+    it("should handle name collisions", () => {
+      const directory = new Directory("src");
+      const fileA = new File("file.js", FileType.JavaScript);
+      const fileB = new File("file.js", FileType.JavaScript);
+      directory.addFile(fileA);
+      directory.addFile(fileB);
+      expect(fileA.parent).toBe(directory);
+      expect(fileB.parent).toBe(directory);
+      expect(fileA.name).toEqual("file.js");
+      expect(fileB.name).toEqual("file.2.js");
     });
   });
   describe("removeFile", () => {
@@ -190,17 +214,14 @@ describe("Directory tests", () => {
       const file = directory.newFile("file", FileType.JavaScript, true);
       expect(file.isTransient).toEqual(true);
     });
-    it("should not add a new file if one already exists with the same name and type", () => {
-      const directory = new Directory("parent");
-      const file = directory.newFile("file", FileType.JavaScript, true);
-      expect(directory.newFile("file", FileType.JavaScript)).toBe(file);
-      expect(directory.children).toHaveLength(1);
-    });
-    it("should thrown an error if trying to create a file with an existing name but different type", () => {
-      const directory = new Directory("parent");
-      const file = directory.newFile("file", FileType.JavaScript, true);
-      expect(() => directory.newFile("file", FileType.Wasm)).toThrowError();
-      expect(directory.children).toHaveLength(1);
+    it("should handle name collisions", () => {
+      const directory = new Directory("src");
+      const fileA = directory.newFile("file.js", FileType.JavaScript);
+      const fileB = directory.newFile("file.js", FileType.JavaScript);
+      expect(fileA.parent).toBe(directory);
+      expect(fileB.parent).toBe(directory);
+      expect(fileA.name).toEqual("file.js");
+      expect(fileB.name).toEqual("file.2.js");
     });
   });
   describe("getImmediateChild", () => {


### PR DESCRIPTION
Associated Issue: #286 

### Summary of Changes
This improves the handling of name collisions on file/directory move and upload. Instead of preventing the drop, files/directories are renamed to `main.c.2`, `src.2` etc. as proposed in #172

* Name collisions are now handled in Directory.ts when adding a new file
* The DragAndDrop class now accepts dropping files even if there are a name collision
* Tests & upload utilities have been updated

### Test Plan
#### Drag
- Create empty C project
- Create a new file called main.c
- Drag the new main.c into the src directory
- The file should be renamed to main.c.2

#### Upload
- Open the upload file/dir dialog
- Upload a file/directory
- Upload the same file/directory again
- The second upload should be renamed