### PR TITLE
Fix regular file/directory upload

### DIFF
--- a/src/components/UploadFileDialog.tsx
+++ b/src/components/UploadFileDialog.tsx
@@ -90,7 +90,7 @@ export class UploadFileDialog extends React.Component<UploadFileDialogProps, Upl
             <UploadInput
               ref={(ref) => this.uploadInput = ref}
               onChange={(e) => {
-                this.handleUpload(e.target.items);
+                this.handleUpload(e.target.files);
               }}
             />
           </div>

--- a/src/util.ts
+++ b/src/util.ts
@@ -253,8 +253,8 @@ export async function readUploadedDirectory(inputEntry: any, root: Directory, cu
   }));
 }
 
-export async function uploadFilesToDirectory(items: DataTransferItemList, root: Directory) {
-  Array.from(items).forEach(async (item: DataTransferItem) => {
+export async function uploadFilesToDirectory(items: any, root: Directory) {
+  Array.from(items).forEach(async (item: any) => {
     if (typeof item.webkitGetAsEntry === "function") {
       const entry = item.webkitGetAsEntry();
       if (entry.isDirectory) {
@@ -265,7 +265,12 @@ export async function uploadFilesToDirectory(items: DataTransferItemList, root: 
         return readUploadedDirectory(entry, root);
       }
     }
-    const file: File = item.getAsFile();
+    let file: File;
+    if (item instanceof DataTransferItem) {
+      file = item.getAsFile();
+    } else {
+      file = item;
+    }
     const name: string = file.name;
     const path: string = file.webkitRelativePath || name; // This works in FF also.
     const fileType = fileTypeForExtension(name.split(".").pop());

--- a/tests/components/UploadFileDialog/UploadFileDialog.spec.tsx
+++ b/tests/components/UploadFileDialog/UploadFileDialog.spec.tsx
@@ -181,8 +181,8 @@ describe("Tests for UploadFileDialog", () => {
     const uploadFilesToDirectory = jest.spyOn(utils, "uploadFilesToDirectory");
     const { wrapper, addDirectory } = setup();
     const { root } = addDirectory("src");
-    const items = [];
-    wrapper.find(UploadInput).simulate("change", { target: { items }});
-    expect(uploadFilesToDirectory).toHaveBeenCalledWith(items, root.getModel());
+    const files = [];
+    wrapper.find(UploadInput).simulate("change", { target: { files }});
+    expect(uploadFilesToDirectory).toHaveBeenCalledWith(files, root.getModel());
   });
 });


### PR DESCRIPTION
Associated Issue: #333

### Summary of Changes
* Handling both DataTransferItemLists and FileLists in `uploadFilesToDirectory`
* Using `e.target.files` instead of `e.target.items` in the `<UploadInput />` onChange handler
* Updated one test case

### Test plan
- Create empty C project
- Open the upload file/dir dialog
- Upload a file/directory by clicking on the Files / Directory buttons
- Upload a file/directory via drag and drop
- Both regular upload and dnd should be working in FF and Chrome