### PR TITLE
Setting the Stryker logLevel to fatal

### DIFF
--- a/stryker.conf.js
+++ b/stryker.conf.js
@@ -13,6 +13,7 @@ module.exports = function(config) {
       "src/**/*.ts?(x)",
       "!src/**/**.d.ts"
     ],
-    timeoutMs: 60000
+    timeoutMs: 60000,
+    logLevel: "fatal"
   });
 };


### PR DESCRIPTION
This silences annoying UnhandledPromiseRejection warnings (due to the code being mutated) while running mutation testing.

### Summary of Changes
* Setting the Stryker logLevel to fatal (in stryker.conf.js)