### PR TITLE
Fix upload & improve the handling of name collisions

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -681,7 +681,6 @@ export class App extends React.Component<AppProps, AppState> {
             this.setState({ uploadFileDialogDirectory: null });
           }}
           onUpload={(files: File[]) => {
-            // TODO: Handle file collisions.
             files.map((file: File) => {
               addFileTo(file, this.state.uploadFileDialogDirectory.getModel());
             });

--- a/src/components/UploadFileDialog.tsx
+++ b/src/components/UploadFileDialog.tsx
@@ -90,7 +90,7 @@ export class UploadFileDialog extends React.Component<UploadFileDialogProps, Upl
             <UploadInput
               ref={(ref) => this.uploadInput = ref}
               onChange={(e) => {
-                this.handleUpload(e.target.items);
+                this.handleUpload(e.target.files);
               }}
             />
           </div>

--- a/src/monaco-dnd.ts
+++ b/src/monaco-dnd.ts
@@ -83,8 +83,7 @@ export class DragAndDrop implements IDragAndDrop {
     return {
       accept: targetElement instanceof Directory &&
               targetElement !== file &&
-              !targetElement.isDescendantOf(file) &&
-              !targetElement.getImmediateChild(file.name),
+              !targetElement.isDescendantOf(file),
       bubble: DragOverBubble.BUBBLE_DOWN,
       autoExpand: true
     };

--- a/src/util.ts
+++ b/src/util.ts
@@ -225,20 +225,25 @@ export async function readUploadedFile(inputFile: File, readAs: "text" | "arrayB
   });
 }
 
-export async function readUploadedDirectory(inputEntry: any, root: Directory) {
+export async function readUploadedDirectory(inputEntry: any, root: Directory, customRoot?: string) {
   const reader = inputEntry.createReader();
   reader.readEntries(((entries: any) => {
     entries.forEach(async (entry: any) => {
       if (entry.isDirectory) {
-        return readUploadedDirectory(entry, root);
+        return readUploadedDirectory(entry, root, customRoot);
       }
       entry.file(async (file: File) => {
         try {
           const name: string = file.name;
-          const path: string = entry.fullPath.replace(/^\/+/g, "");
+          let path: string = entry.fullPath.replace(/^\/+/g, "");
+          if (customRoot) {
+            const pathArray = path.split("/");
+            pathArray[0] = customRoot;
+            path = pathArray.join("/");
+          }
           const fileType = fileTypeForExtension(name.split(".").pop());
           const data = await readUploadedFile(file, isBinaryFileType(fileType) ? "arrayBuffer" : "text");
-          const newFile = root.newFile(path, fileType);
+          const newFile = root.newFile(path, fileType, false, true);
           newFile.setData(data);
         } catch (e) {
           console.log("Unable to read the file!");
@@ -248,22 +253,31 @@ export async function readUploadedDirectory(inputEntry: any, root: Directory) {
   }));
 }
 
-export async function uploadFilesToDirectory(items: DataTransferItemList, root: Directory) {
-  Array.from(items).forEach(async (item: DataTransferItem) => {
+export async function uploadFilesToDirectory(items: any, root: Directory) {
+  Array.from(items).forEach(async (item: any) => {
     if (typeof item.webkitGetAsEntry === "function") {
       const entry = item.webkitGetAsEntry();
       if (entry.isDirectory) {
+        if (root.getImmediateChild(entry.name)) {
+          const customRoot = root.handleNameCollision(entry.name);
+          return readUploadedDirectory(entry, root, customRoot);
+        }
         return readUploadedDirectory(entry, root);
       }
     }
-    const file: File = item.getAsFile();
+    let file: File;
+    if (item instanceof DataTransferItem) {
+      file = item.getAsFile();
+    } else {
+      file = item;
+    }
     const name: string = file.name;
     const path: string = file.webkitRelativePath || name; // This works in FF also.
     const fileType = fileTypeForExtension(name.split(".").pop());
     let data: any;
     try {
       data = await readUploadedFile(file, isBinaryFileType(fileType) ? "arrayBuffer" : "text");
-      const newFile = root.newFile(path, fileType);
+      const newFile = root.newFile(path, fileType, false, true);
       newFile.setData(data);
     } catch (e) {
       console.log("Unable to read the file!");

--- a/tests/components/UploadFileDialog/UploadFileDialog.spec.tsx
+++ b/tests/components/UploadFileDialog/UploadFileDialog.spec.tsx
@@ -181,8 +181,8 @@ describe("Tests for UploadFileDialog", () => {
     const uploadFilesToDirectory = jest.spyOn(utils, "uploadFilesToDirectory");
     const { wrapper, addDirectory } = setup();
     const { root } = addDirectory("src");
-    const items = [];
-    wrapper.find(UploadInput).simulate("change", { target: { items }});
-    expect(uploadFilesToDirectory).toHaveBeenCalledWith(items, root.getModel());
+    const files = [];
+    wrapper.find(UploadInput).simulate("change", { target: { files }});
+    expect(uploadFilesToDirectory).toHaveBeenCalledWith(files, root.getModel());
   });
 });

--- a/tests/unit/DragAndDrop.spec.ts
+++ b/tests/unit/DragAndDrop.spec.ts
@@ -102,21 +102,6 @@ describe("Tests for DragAndDrop", () => {
         autoExpand: true
       });
     });
-    it("should disable drop on name collisions", () => {
-      const dnd = new DragAndDrop({});
-      const file = new File("file", FileType.JavaScript);
-      const data = {
-        elements: [file],
-        getData: () => [file]
-      } as any;
-      const targetElement = new Directory("src");
-      targetElement.addFile(file);
-      expect(dnd.onDragOver(null, data, targetElement, null)).toEqual({
-        accept: false,
-        bubble: DragOverBubble.BUBBLE_DOWN,
-        autoExpand: true
-      });
-    });
     it("should disable drop when a folder is being moved into its own child", () => {
       const dnd = new DragAndDrop({});
       const parent = new Directory("parent");

--- a/tests/unit/directory.spec.ts
+++ b/tests/unit/directory.spec.ts
@@ -81,6 +81,26 @@ describe("Directory tests", () => {
       expect(callback.mock.calls[0][0]).toBe(c);
     });
   });
+  describe("handleNameCollision", () => {
+    it("should handle name collisions for file names", () => {
+      const directory = new Directory("src");
+      const fileA = directory.newFile("file.js", FileType.JavaScript);
+      const fileB = directory.newFile("file.js", FileType.JavaScript, false, true);
+      const fileC = new File("file.js", FileType.JavaScript);
+      expect(fileB.name).toEqual("file.2.js");
+      expect(directory.handleNameCollision(fileC.name)).toEqual("file.3.js");
+    });
+    it("should handle name collisions for directory names", () => {
+      const root = new Directory("src");
+      const dirA = root.newDirectory("dir");
+      const dirB = new Directory("dir");
+      expect(root.handleNameCollision(dirB.name, true)).toEqual("dir2");
+    });
+    it("should throw an error if name collision was not handled", () => {
+      const root = new Directory("src");
+      expect(() => root.handleNameCollision("test")).toThrowError("Name collision not handled");
+    });
+  });
   describe("addFile", () => {
     it("should add the file", () => {
       const file = new File("file", FileType.JavaScript);
@@ -96,13 +116,6 @@ describe("Directory tests", () => {
       directoryA.addFile(file);
       expect(() => directoryB.addFile(file)).toThrowError();
     });
-    it("should assert that there isn't already a file with the same name", () => {
-      const fileA = new File("file", FileType.JavaScript);
-      const fileB = new File("file", FileType.JavaScript);
-      const directory = new Directory("src");
-      directory.addFile(fileA);
-      expect(() => directory.addFile(fileB)).toThrowError();
-    });
     it("should dispatch an onDidChangeChildren event", () => {
       const file = new File("file", FileType.JavaScript);
       const directory = new Directory("src");
@@ -110,6 +123,17 @@ describe("Directory tests", () => {
       directory.onDidChangeChildren.register(callback);
       directory.addFile(file);
       expect(callback).toHaveBeenCalled();
+    });
+    it("should handle name collisions", () => {
+      const directory = new Directory("src");
+      const fileA = new File("file.js", FileType.JavaScript);
+      const fileB = new File("file.js", FileType.JavaScript);
+      directory.addFile(fileA);
+      directory.addFile(fileB);
+      expect(fileA.parent).toBe(directory);
+      expect(fileB.parent).toBe(directory);
+      expect(fileA.name).toEqual("file.js");
+      expect(fileB.name).toEqual("file.2.js");
     });
   });
   describe("removeFile", () => {
@@ -190,17 +214,20 @@ describe("Directory tests", () => {
       const file = directory.newFile("file", FileType.JavaScript, true);
       expect(file.isTransient).toEqual(true);
     });
-    it("should not add a new file if one already exists with the same name and type", () => {
-      const directory = new Directory("parent");
-      const file = directory.newFile("file", FileType.JavaScript, true);
-      expect(directory.newFile("file", FileType.JavaScript)).toBe(file);
-      expect(directory.children).toHaveLength(1);
+    it("should handle name collisions if specified", () => {
+      const directory = new Directory("src");
+      const fileA = directory.newFile("file.js", FileType.JavaScript, false, true);
+      const fileB = directory.newFile("file.js", FileType.JavaScript, false, true);
+      expect(fileA.parent).toBe(directory);
+      expect(fileB.parent).toBe(directory);
+      expect(fileA.name).toEqual("file.js");
+      expect(fileB.name).toEqual("file.2.js");
     });
-    it("should thrown an error if trying to create a file with an existing name but different type", () => {
-      const directory = new Directory("parent");
-      const file = directory.newFile("file", FileType.JavaScript, true);
-      expect(() => directory.newFile("file", FileType.Wasm)).toThrowError();
-      expect(directory.children).toHaveLength(1);
+    it("should not handle name collisions by default", () => {
+      const directory = new Directory("src");
+      const fileA = directory.newFile("file.js", FileType.JavaScript);
+      const fileB = directory.newFile("file.js", FileType.JavaScript);
+      expect(fileA).toBe(fileB);
     });
   });
   describe("getImmediateChild", () => {


### PR DESCRIPTION
Associated Issue: #333, #286 

This is a slight rework of PR #334 and #332 combined that addresses the issue described in #335 (Each build creates a new WASM file).

### Summary of Changes
* Fix file/directory upload via regular input
* Handle name collisions when moving/uploading files (but not when building/assembling/disassembling etc)

### Test Plan
#### Name collision (Drag)
- Create empty C project
- Create a new file called main.c
- Drag the new main.c into the src directory
- The file should be renamed

#### Name collision (Upload)
- Open the upload file/dir dialog
- Upload a file/directory
- Upload the same file/directory again
- The second upload should be renamed

#### Name collision (Build)
- Create empty C project
- Build it
- Build it again
- It should not generate more than one wasm file

#### Upload
- Create empty C project
- Open the upload file/dir dialog
- Upload a file/directory by clicking on the Files / Directory buttons
- Upload a file/directory via drag and drop
- Both regular upload and dnd should be working in FF and Chrome
