### PR TITLE
Adding jest-puppeteer and simple e2e test

### DIFF
--- a/jest-puppeteer.config.js
+++ b/jest-puppeteer.config.js
@@ -1,0 +1,11 @@
+module.exports = {
+  server: {
+    command: 'npm run dev-server',
+    launchTimeout: 60000,
+    usedPortAction: 'ignore',
+    port: 28443
+  },
+  launch: {
+    ignoreHTTPSErrors: true
+  }
+}

--- a/jest.e2e.config.json
+++ b/jest.e2e.config.json
@@ -1,0 +1,19 @@
+{
+  "setupFiles": [
+    "<rootDir>/test-shim.js",
+    "<rootDir>/test-setup.js"
+  ],
+  "moduleFileExtensions": [
+    "ts",
+    "tsx",
+    "js"
+  ],
+  "transform": {
+    "^.+\\.(ts|tsx)$": "<rootDir>/test-preprocessor.js"
+  },
+  "testMatch": [
+    "**/tests/**/**/**.e2e.(ts|tsx|js)"
+  ],
+  "testURL": "https://webassembly.studio/",
+  "preset": "jest-puppeteer"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -77,6 +77,22 @@
         "@types/react": "16.4.5"
       }
     },
+    "@types/events": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@types/events/-/events-1.2.0.tgz",
+      "integrity": "sha512-KEIlhXnIutzKwRbQkGWb/I4HFqBuUykAdHgDED6xqwXJfONCjF5VoE0cXEiurh3XauygxzeDzgtXUqvLkxFzzA==",
+      "dev": true
+    },
+    "@types/expect-puppeteer": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/@types/expect-puppeteer/-/expect-puppeteer-2.2.4.tgz",
+      "integrity": "sha512-4rUomFJV/Jj9hEr3Ruk1MIl9dRtO0KSdEWxPno6rfZIPe8cLcL4yl+v3jh5ipcKcL59sHMklF415qMOBOvPgTw==",
+      "dev": true,
+      "requires": {
+        "@types/jest": "22.2.3",
+        "@types/puppeteer": "1.5.1"
+      }
+    },
     "@types/fbemitter": {
       "version": "2.0.32",
       "resolved": "https://registry.npmjs.org/@types/fbemitter/-/fbemitter-2.0.32.tgz",
@@ -96,6 +112,15 @@
       "resolved": "https://registry.npmjs.org/@types/jest/-/jest-22.2.3.tgz",
       "integrity": "sha512-e74sM9W/4qqWB6D4TWV9FQk0WoHtX1X4FJpbjxucMSVJHtFjbQOH3H6yp+xno4br0AKG0wz/kPtaN599GUOvAg==",
       "dev": true
+    },
+    "@types/jest-environment-puppeteer": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@types/jest-environment-puppeteer/-/jest-environment-puppeteer-2.2.1.tgz",
+      "integrity": "sha512-jY3BOc+oAMls2Yl0HSXulCoqQoDgHBIgshulIcKwl9ZS+rlIdDPwfdN1Mvl973D2sl7FgwCfjI+pVkiaZBCqcw==",
+      "dev": true,
+      "requires": {
+        "@types/puppeteer": "1.5.1"
+      }
     },
     "@types/jszip": {
       "version": "3.1.4",
@@ -124,6 +149,16 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@types/pako/-/pako-1.0.0.tgz",
       "integrity": "sha1-6q6DZNG391LiY7w/1o3+yY5hNsU="
+    },
+    "@types/puppeteer": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@types/puppeteer/-/puppeteer-1.5.1.tgz",
+      "integrity": "sha512-t++RBCHekDaTDrz6TcMp8obfm9Kd6CVJuIcilUMMJU2haxv2zX/forXRKmBtZtspJTmuhT9rMysNQgj/Drilag==",
+      "dev": true,
+      "requires": {
+        "@types/events": "1.2.0",
+        "@types/node": "10.0.3"
+      }
     },
     "@types/react": {
       "version": "16.4.5",
@@ -465,6 +500,15 @@
       "dev": true,
       "requires": {
         "acorn": "5.5.3"
+      }
+    },
+    "agent-base": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.1.tgz",
+      "integrity": "sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==",
+      "dev": true,
+      "requires": {
+        "es6-promisify": "5.0.0"
       }
     },
     "ajv": {
@@ -3143,6 +3187,16 @@
         "array-find-index": "1.0.2"
       }
     },
+    "cwd": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/cwd/-/cwd-0.10.0.tgz",
+      "integrity": "sha1-FyQAaUBXwioTsM8WFix+S3p/5Wc=",
+      "dev": true,
+      "requires": {
+        "find-pkg": "0.1.2",
+        "fs-exists-sync": "0.1.0"
+      }
+    },
     "cyclist": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-0.2.2.tgz",
@@ -3822,6 +3876,23 @@
       "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.0.2.tgz",
       "integrity": "sha1-AQ1YWEI6XxGJeWZfRkhqlcbuK7Y="
     },
+    "es6-promisify": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+      "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
+      "dev": true,
+      "requires": {
+        "es6-promise": "4.2.4"
+      },
+      "dependencies": {
+        "es6-promise": {
+          "version": "4.2.4",
+          "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.4.tgz",
+          "integrity": "sha512-/NdNZVJg+uZgtm9eS3O6lrOLYmQag2DjdEXuPaHlZ6RuVqgqaVZfgYCepEIKsLqwdQArOPtC3XzRLqGGfT8KQQ==",
+          "dev": true
+        }
+      }
+    },
     "es6-symbol": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
@@ -3914,6 +3985,21 @@
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
       "dev": true
+    },
+    "event-stream": {
+      "version": "3.3.4",
+      "resolved": "http://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+      "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
+      "dev": true,
+      "requires": {
+        "duplexer": "0.1.1",
+        "from": "0.1.7",
+        "map-stream": "0.1.0",
+        "pause-stream": "0.0.11",
+        "split": "0.3.3",
+        "stream-combiner": "0.0.4",
+        "through": "2.3.8"
+      }
     },
     "eventemitter3": {
       "version": "3.1.0",
@@ -4096,6 +4182,12 @@
         "jest-regex-util": "22.4.3"
       }
     },
+    "expect-puppeteer": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/expect-puppeteer/-/expect-puppeteer-3.2.0.tgz",
+      "integrity": "sha1-tMMi4ouG6edPXG1jb7Hg3eXEpVk=",
+      "dev": true
+    },
     "express": {
       "version": "4.16.3",
       "resolved": "https://registry.npmjs.org/express/-/express-4.16.3.tgz",
@@ -4257,6 +4349,18 @@
         }
       }
     },
+    "extract-zip": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.6.7.tgz",
+      "integrity": "sha1-qEC0uK9kAyZMjbV/Txp0Mz74H+k=",
+      "dev": true,
+      "requires": {
+        "concat-stream": "1.6.2",
+        "debug": "2.6.9",
+        "mkdirp": "0.5.1",
+        "yauzl": "2.4.1"
+      }
+    },
     "extsprintf": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
@@ -4379,6 +4483,15 @@
         "ua-parser-js": "0.7.18"
       }
     },
+    "fd-slicer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
+      "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
+      "dev": true,
+      "requires": {
+        "pend": "1.2.0"
+      }
+    },
     "figures": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
@@ -4463,6 +4576,85 @@
         "commondir": "1.0.1",
         "make-dir": "1.3.0",
         "pkg-dir": "2.0.0"
+      }
+    },
+    "find-file-up": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/find-file-up/-/find-file-up-0.1.3.tgz",
+      "integrity": "sha1-z2gJG8+fMApA2kEbN9pczlovvqA=",
+      "dev": true,
+      "requires": {
+        "fs-exists-sync": "0.1.0",
+        "resolve-dir": "0.1.1"
+      },
+      "dependencies": {
+        "expand-tilde": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-1.2.2.tgz",
+          "integrity": "sha1-C4HrqJflo9MdHD0QL48BRB5VlEk=",
+          "dev": true,
+          "requires": {
+            "os-homedir": "1.0.2"
+          }
+        },
+        "global-modules": {
+          "version": "0.2.3",
+          "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-0.2.3.tgz",
+          "integrity": "sha1-6lo77ULG1s6ZWk+KEmm12uIjgo0=",
+          "dev": true,
+          "requires": {
+            "global-prefix": "0.1.5",
+            "is-windows": "0.2.0"
+          }
+        },
+        "global-prefix": {
+          "version": "0.1.5",
+          "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-0.1.5.tgz",
+          "integrity": "sha1-jTvGuNo8qBEqFg2NSW/wRiv+948=",
+          "dev": true,
+          "requires": {
+            "homedir-polyfill": "1.0.1",
+            "ini": "1.3.5",
+            "is-windows": "0.2.0",
+            "which": "1.3.0"
+          }
+        },
+        "is-windows": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-0.2.0.tgz",
+          "integrity": "sha1-3hqm1j6indJIc3tp8f+LgALSEIw=",
+          "dev": true
+        },
+        "resolve-dir": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-0.1.1.tgz",
+          "integrity": "sha1-shklmlYC+sXFxJatiUpujMQwJh4=",
+          "dev": true,
+          "requires": {
+            "expand-tilde": "1.2.2",
+            "global-modules": "0.2.3"
+          }
+        }
+      }
+    },
+    "find-pkg": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/find-pkg/-/find-pkg-0.1.2.tgz",
+      "integrity": "sha1-G9wiwG42NlUy4qJIBGhUuXiNpVc=",
+      "dev": true,
+      "requires": {
+        "find-file-up": "0.1.3"
+      }
+    },
+    "find-process": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/find-process/-/find-process-1.1.1.tgz",
+      "integrity": "sha1-V/sa28f0MEeG23IKSf69cIoxYtQ=",
+      "dev": true,
+      "requires": {
+        "chalk": "2.4.1",
+        "commander": "2.15.1",
+        "debug": "2.6.9"
       }
     },
     "find-up": {
@@ -4593,6 +4785,12 @@
       "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
       "dev": true
     },
+    "from": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
+      "integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4=",
+      "dev": true
+    },
     "from2": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
@@ -4602,6 +4800,12 @@
         "inherits": "2.0.3",
         "readable-stream": "2.0.6"
       }
+    },
+    "fs-exists-sync": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz",
+      "integrity": "sha1-mC1ok6+RjnLQjeyehnP/K1qNat0=",
+      "dev": true
     },
     "fs-write-stream-atomic": {
       "version": "1.0.10",
@@ -5802,6 +6006,27 @@
       "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
       "dev": true
     },
+    "https-proxy-agent": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
+      "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
+      "dev": true,
+      "requires": {
+        "agent-base": "4.2.1",
+        "debug": "3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
     "iconv-lite": {
       "version": "0.4.21",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.21.tgz",
@@ -6768,6 +6993,21 @@
         "pretty-format": "22.4.3"
       }
     },
+    "jest-dev-server": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/jest-dev-server/-/jest-dev-server-3.2.0.tgz",
+      "integrity": "sha1-Gf5g7hVgyv/E8W9In680R52c28Y=",
+      "dev": true,
+      "requires": {
+        "chalk": "2.4.1",
+        "cwd": "0.10.0",
+        "find-process": "1.1.1",
+        "inquirer": "6.0.0",
+        "spawnd": "2.0.0",
+        "terminate": "2.1.0",
+        "wait-port": "0.2.2"
+      }
+    },
     "jest-diff": {
       "version": "22.4.3",
       "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-22.4.3.tgz",
@@ -6817,6 +7057,20 @@
       "requires": {
         "jest-mock": "22.4.3",
         "jest-util": "22.4.3"
+      }
+    },
+    "jest-environment-puppeteer": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/jest-environment-puppeteer/-/jest-environment-puppeteer-3.2.1.tgz",
+      "integrity": "sha1-xS6aqY8HtS83hyHV8f8PAAxODp8=",
+      "dev": true,
+      "requires": {
+        "chalk": "2.4.1",
+        "cwd": "0.10.0",
+        "jest-dev-server": "3.2.0",
+        "lodash": "4.17.10",
+        "mkdirp": "0.5.1",
+        "rimraf": "2.6.2"
       }
     },
     "jest-enzyme": {
@@ -7060,6 +7314,16 @@
       "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-22.4.3.tgz",
       "integrity": "sha512-+4R6mH5M1G4NK16CKg9N1DtCaFmuxhcIqF4lQK/Q1CIotqMs/XBemfpDPeVZBFow6iyUNu6EBT9ugdNOTT5o5Q==",
       "dev": true
+    },
+    "jest-puppeteer": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/jest-puppeteer/-/jest-puppeteer-3.2.1.tgz",
+      "integrity": "sha1-cvasvoLy/eFnjwaTEGWD7ec0560=",
+      "dev": true,
+      "requires": {
+        "expect-puppeteer": "3.2.0",
+        "jest-environment-puppeteer": "3.2.1"
+      }
     },
     "jest-regex-util": {
       "version": "22.4.3",
@@ -8250,6 +8514,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
       "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
+      "dev": true
+    },
+    "map-stream": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
+      "integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ=",
       "dev": true
     },
     "map-visit": {
@@ -9515,6 +9785,15 @@
         "pinkie-promise": "2.0.1"
       }
     },
+    "pause-stream": {
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+      "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
+      "dev": true,
+      "requires": {
+        "through": "2.3.8"
+      }
+    },
     "pbkdf2": {
       "version": "3.0.16",
       "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.16.tgz",
@@ -9527,6 +9806,12 @@
         "safe-buffer": "5.1.2",
         "sha.js": "2.4.11"
       }
+    },
+    "pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
+      "dev": true
     },
     "performance-now": {
       "version": "2.1.0",
@@ -10203,11 +10488,26 @@
         "ipaddr.js": "1.6.0"
       }
     },
+    "proxy-from-env": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.0.0.tgz",
+      "integrity": "sha1-M8UDmPcOp+uW0h97gXYwpVeRx+4=",
+      "dev": true
+    },
     "prr": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
       "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
       "dev": true
+    },
+    "ps-tree": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/ps-tree/-/ps-tree-1.1.0.tgz",
+      "integrity": "sha1-tCGyQUDWID8e08dplrRCewjowBQ=",
+      "dev": true,
+      "requires": {
+        "event-stream": "3.3.4"
+      }
     },
     "pseudomap": {
       "version": "1.0.2",
@@ -10254,6 +10554,48 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
       "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
       "dev": true
+    },
+    "puppeteer": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-1.6.1.tgz",
+      "integrity": "sha512-qz6DLwK+PhlBMjJZOMOsgVCnweYLtmiqnmJYUDPT++ElMz+cQgbsCNKPw4YDVpg3RTbsRX/pqQqr20zrp0cuKw==",
+      "dev": true,
+      "requires": {
+        "debug": "3.1.0",
+        "extract-zip": "1.6.7",
+        "https-proxy-agent": "2.2.1",
+        "mime": "2.3.1",
+        "progress": "2.0.0",
+        "proxy-from-env": "1.0.0",
+        "rimraf": "2.6.2",
+        "ws": "5.2.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "mime": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.3.1.tgz",
+          "integrity": "sha512-OEUllcVoydBHGN1z84yfQDimn58pZNNNXgZlHXSboxMlFvgI6MXSWpWKpFRra7H1HxpVhHTkrghfRW49k6yjeg==",
+          "dev": true
+        },
+        "ws": {
+          "version": "5.2.2",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.2.tgz",
+          "integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
+          "dev": true,
+          "requires": {
+            "async-limiter": "1.0.0"
+          }
+        }
+      }
     },
     "q": {
       "version": "1.5.1",
@@ -11483,6 +11825,18 @@
       "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
       "dev": true
     },
+    "spawnd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/spawnd/-/spawnd-2.0.0.tgz",
+      "integrity": "sha1-0gIEA9xe9y7Kw/+rm0L6Fq6RdfU=",
+      "dev": true,
+      "requires": {
+        "exit": "0.1.2",
+        "signal-exit": "3.0.2",
+        "terminate": "2.1.0",
+        "wait-port": "0.2.2"
+      }
+    },
     "spdx-correct": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
@@ -11576,6 +11930,15 @@
         }
       }
     },
+    "split": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
+      "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
+      "dev": true,
+      "requires": {
+        "through": "2.3.8"
+      }
+    },
     "split-string": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -11663,6 +12026,15 @@
       "requires": {
         "inherits": "2.0.3",
         "readable-stream": "2.0.6"
+      }
+    },
+    "stream-combiner": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
+      "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
+      "dev": true,
+      "requires": {
+        "duplexer": "0.1.1"
       }
     },
     "stream-each": {
@@ -12152,6 +12524,15 @@
           "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI=",
           "dev": true
         }
+      }
+    },
+    "terminate": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/terminate/-/terminate-2.1.0.tgz",
+      "integrity": "sha1-qH7kJL4BodKPLzAQRQQ6W81nmgU=",
+      "dev": true,
+      "requires": {
+        "ps-tree": "1.1.0"
       }
     },
     "test-exclude": {
@@ -12961,6 +13342,53 @@
       "dev": true,
       "requires": {
         "browser-process-hrtime": "0.1.2"
+      }
+    },
+    "wait-port": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/wait-port/-/wait-port-0.2.2.tgz",
+      "integrity": "sha1-1RpJHkhKF791qUfnEaLwErTm8uM=",
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "commander": "2.15.1",
+        "debug": "2.6.9"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        }
       }
     },
     "walker": {
@@ -13856,6 +14284,15 @@
           "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
           "dev": true
         }
+      }
+    },
+    "yauzl": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz",
+      "integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
+      "dev": true,
+      "requires": {
+        "fd-slicer": "1.0.1"
       }
     },
     "yeoman-environment": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "tslint": "tslint -p ./tsconfig.json; tslint -p ./tsconfig.test.json",
     "templates": "bin/build-templates.sh && bin/build-arc-templates.sh",
     "mutate": "./node_modules/.bin/stryker run",
-    "analyse": "mkdir -p ./stats && webpack --profile --json > ./stats/stats.json && webpack-bundle-analyzer ./stats/stats.json ./dist -r stats/index.html"
+    "analyse": "mkdir -p ./stats && webpack --profile --json > ./stats/stats.json && webpack-bundle-analyzer ./stats/stats.json ./dist -r stats/index.html",
+    "e2e": "jest --maxWorkers=2 -c jest.e2e.config.json"
   },
   "jest": {
     "setupTestFrameworkScriptFile": "./node_modules/jest-enzyme/lib/index.js",
@@ -77,7 +78,10 @@
   "devDependencies": {
     "@types/base64-js": "^1.2.5",
     "@types/enzyme": "^3.1.11",
+    "@types/expect-puppeteer": "^2.2.4",
     "@types/jest": "^22.1.4",
+    "@types/jest-environment-puppeteer": "^2.2.1",
+    "@types/puppeteer": "^1.5.1",
     "@types/react": "^16.4.5",
     "@types/react-dom": "^16.0.6",
     "base64-js": "^1.3.0",
@@ -87,7 +91,9 @@
     "enzyme-adapter-react-16": "^1.1.1",
     "jest": "^22.4.4",
     "jest-enzyme": "^6.0.2",
+    "jest-puppeteer": "^3.2.1",
     "monaco-editor-webpack-plugin": "^1.3.0",
+    "puppeteer": "^1.6.1",
     "react-test-renderer": "^16.4.1",
     "source-map-loader": "^0.2.3",
     "stryker": "^0.25.1",

--- a/tests/e2e/EmptyCProject.e2e.ts
+++ b/tests/e2e/EmptyCProject.e2e.ts
@@ -1,0 +1,64 @@
+/* Any copyright is dedicated to the Public Domain.
+ * http://creativecommons.org/publicdomain/zero/1.0/ */
+
+async function getDirectoryStructure() {
+  return await page.evaluate((selector) => {
+    const elements = Array.from(document.querySelectorAll(selector));
+    return elements.map(element => element.textContent);
+  }, "a.label-name");
+}
+
+async function getRunResults() {
+  return await page.evaluate((selector) => {
+    const iframe = document.querySelector(selector);
+    return iframe.contentWindow.document.body.querySelector("span#container").textContent;
+  }, "iframe");
+}
+
+describe("Empty C Project: Create, Build and Run", () => {
+  beforeAll(async () => {
+    jest.setTimeout(30000);
+    await page.goto("https://localhost:28443");
+  });
+  it("should initialy display the Create New Project dialog", async () => {
+    await expect(page).toMatch("Empty C Project");
+  });
+  it("should create an Empty C Project when clicking the Create button", async () => {
+    await page.click("div.button[title=\"Create\"]");
+    await page.waitForSelector("a.label-name");
+    await expect(getDirectoryStructure()).resolves.toEqual([
+      "README.md",
+      "build.ts",
+      "package.json",
+      "src",
+      "main.c",
+      "main.html",
+      "main.js"
+    ]);
+  });
+  it("should build the project when clicking the Build button", async () => {
+    // Click the build button and wait for the request to finish
+    await page.click("div.button[title=\"Build Project: CtrlCmd + B\"]");
+    await page.waitFor(3000); // TODO: Remove hardcoded wait duration
+    // Build a second time
+    await page.click("div.button[title=\"Build Project: CtrlCmd + B\"]");
+    await page.waitFor(3000); // TODO: Remove hardcoded wait duration
+    await expect(getDirectoryStructure()).resolves.toEqual([
+      "README.md",
+      "build.ts",
+      "package.json",
+      "src",
+      "main.c",
+      "main.html",
+      "main.js",
+      "out",
+      "main.wasm"
+    ]);
+  });
+  it("should run the project when clicking the Run button", async () => {
+    // Click the run button and wait for the results
+    await page.click("div.button[title=\"Run Project: CtrlCmd + Enter\"]");
+    await page.waitFor(1000); // TODO: Remove hardcoded wait duration
+    await expect(getRunResults()).resolves.toEqual("42");
+  });
+});


### PR DESCRIPTION
Associated Issue: #348  

### Summary of Changes
* Setting up an end-to-end testing environment (puppeteer + jest-puppeteer)
* Adding a simple end-to-end test suite that creates, builds and runs the Empty C Project.

### Thoughts
* Implementing end-to-end tests for some key functionality may help us catch stuff that individual unit tests might not.
* End-to-end tests would be great to run when merging PRs into master (Maybe this can be setup in Travis somehow?).
* When installing Puppeteer, it downloads a recent version of Chromium (~170Mb Mac, ~282Mb Linux, ~280Mb Win) which might be a downside

### Test Plan
* `npm run e2e`