### PR TITLE
Improve error message during sandbox run

### DIFF
--- a/src/components/Sandbox.tsx
+++ b/src/components/Sandbox.tsx
@@ -85,7 +85,7 @@ export class Sandbox extends React.Component<{}, {}>  {
       error.apply(contentWindow.console, arguments);
     })(contentWindow.console.error);
     // Hijack fetch
-    contentWindow.fetch = (input: string, init?: RequestInit) => {
+    contentWindow.fetch =  async (input: string, init?: RequestInit) => {
       const url = new URL(input, "http://example.org/src/main.html");
       const file = project.getFile(url.pathname.substr(1));
       if (file) {
@@ -99,7 +99,12 @@ export class Sandbox extends React.Component<{}, {}>  {
           })
         );
       }
-      return fetch(input, init);
+      const response = await fetch(input, init);
+      if (response.status === 404) {
+        return Promise.reject(`Failed to fetch: ${response.url}`);
+      } else {
+        return Promise.resolve(response);
+      }
     };
     contentWindow.getFileURL = (path: string) => {
       const file = project.getFile(path);


### PR DESCRIPTION
Associated Issue: #351 Failed to fetch

Disabling the Run button and when the project is build the Run button is enable .

I tested by Running locally "hello world"  project  in C.

Example test plan:

- [x] Create C "hello, world" project
- [x] Click Build button 
- [x] Click Run button, and observe the Result panel
- [x] Clicking the "x" on the Result panel closes it

