### PR TITLE
Run e2e tests in Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ install:
 - npm install
 script:
 - npm test
+- npm run e2e
 - npm run coveralls
 - npm run templates
 - cp .gitignore.travis .gitignore

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "coveralls": "jest --coverage --no-cache --maxWorkers=2 && cat ./coverage/lcov.info | coveralls",
     "clean": "rm -r dist/*",
     "tslint": "tslint -p ./tsconfig.json; tslint -p ./tsconfig.test.json",
-    "templates": "bin/build-templates.sh && bin/build-arc-templates.sh",
+    "templates": "./bin/build-templates.sh && ./bin/build-arc-templates.sh",
     "mutate": "./node_modules/.bin/stryker run",
     "analyse": "mkdir -p ./stats && webpack --profile --json > ./stats/stats.json && webpack-bundle-analyzer ./stats/stats.json ./dist -r stats/index.html",
     "e2e": "jest --maxWorkers=2 -c jest.e2e.config.json"


### PR DESCRIPTION
Associated Issue: #348 

All dependencies that are needed to run the e2e tests are already installed when running `npm install` in the Travis build. Why not also run the tests? (takes about 30s)

### Summary of Changes
* Added `npm run e2e` to the scripts in `.travis.yml`
* Fix paths in the `templates` script in `package.json`