### PR TITLE
Add support for triggering forks from the embedding website

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -335,6 +335,13 @@ export class App extends React.Component<AppProps, AppState> {
         windowDimensions: App.getWindowDimensions(),
       });
     }, false);
+    if (this.props.embeddingParams.type === EmbeddingType.Arc) {
+      window.addEventListener("message", (e) => {
+        if (typeof e.data === "object" && e.data !== null && e.data.type === "arc/fork") {
+          this.fork();
+        }
+      });
+    }
   }
 
   share() {


### PR DESCRIPTION
Associated Issue: none

Here's the contributing guide at https://github.com/wasdk/WebAssemblyStudio/wiki/Contributing

### Summary of Changes

This change allows an embedding website to trigger forking a project, just as if the user had clicked the "fork" button.

### Test Plan

No testing within WebAssembly.Studio—the Arch website will test this.
