### PR TITLE
Always fork before publishing Arc projects

### DIFF
--- a/src/actions/AppActions.ts
+++ b/src/actions/AppActions.ts
@@ -222,7 +222,7 @@ export async function openProjectFiles(template: Template) {
   }
 }
 
-export async function saveProject(fiddle: string) {
+export async function saveProject(fiddle: string): Promise<string> {
   logLn("Saving Project ...");
   const tabGroups = appStore.getTabGroups();
   const projectModel = appStore.getProject().getModel();
@@ -231,12 +231,13 @@ export async function saveProject(fiddle: string) {
     return group.views.map((view) => view.file.getPath());
   });
 
-  await Service.saveProject(projectModel, openedFiles, fiddle);
+  const uri = await Service.saveProject(projectModel, openedFiles, fiddle);
   logLn("Saved Project OK");
 
   dispatcher.dispatch({
     type: AppActionType.CLEAR_PROJECT_MODIFIED,
   } as AppAction);
+  return uri;
 }
 
 export interface FocusTabGroupAction extends AppAction {

--- a/src/arc.ts
+++ b/src/arc.ts
@@ -47,24 +47,4 @@ export class Arc {
       manifest,
     }, "*");
   }
-  public static animationBufferToJSON(animation: ArrayBuffer, rows: number, cols: number,
-                                      frameCount: number): number[][][][] {
-    const json = [];
-    const frameSize = rows * cols * 3;
-    for (let i = 0; i < frameCount; i++) {
-      const buffer = new Uint8Array(animation, frameSize * i, frameSize);
-      const frame: number[][][] = [];
-      json.push(frame);
-
-      let pos = 0;
-      for (let y = 0; y < rows; y++) {
-        const row: number[][] = [];
-        frame.push(row);
-        for (let x = 0; x < cols; x++) {
-          row.push([buffer[pos++], buffer[pos++], buffer[pos++]]);
-        }
-      }
-    }
-    return json;
-  }
 }

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -302,6 +302,14 @@ export class App extends React.Component<AppProps, AppState> {
     openFile(help, defaultViewTypeForFileType(help.type));
   }
 
+  private publishArc(): Promise<void> {
+    if (this.state.isContentModified) {
+      return this.fork().then(publishArc);
+    } else {
+      return publishArc();
+    }
+  }
+
   registerShortcuts() {
     Mousetrap.bind("command+b", () => {
       build();
@@ -310,14 +318,14 @@ export class App extends React.Component<AppProps, AppState> {
       if (this.props.embeddingParams.type !== EmbeddingType.Arc) {
         run();
       } else {
-        publishArc();
+        this.publishArc();
       }
     });
     Mousetrap.bind("command+alt+enter", () => {
       if (this.props.embeddingParams.type !== EmbeddingType.Arc) {
         build().then(run);
       } else {
-        build().then(publishArc);
+        build().then(() => this.publishArc());
       }
     });
   }
@@ -352,9 +360,8 @@ export class App extends React.Component<AppProps, AppState> {
     saveProject(this.state.fiddle);
   }
   async fork() {
-    const projectModel = this.state.project.getModel();
     pushStatus("Forking Project");
-    const fiddle = await Service.saveProject(projectModel, []);
+    const fiddle = await saveProject("");
     popStatus();
     const search = window.location.search;
     if (this.state.fiddle) {
@@ -541,7 +548,7 @@ export class App extends React.Component<AppProps, AppState> {
           title="Preview Project: CtrlCmd + Enter"
           isDisabled={this.toolbarButtonsAreDisabled()}
           onClick={() => {
-            publishArc();
+            this.publishArc();
           }}
         />
       );
@@ -553,7 +560,7 @@ export class App extends React.Component<AppProps, AppState> {
           title="Build &amp; Preview Project: CtrlCmd + Alt + Enter"
           isDisabled={this.toolbarButtonsAreDisabled()}
           onClick={() => {
-            build().then(publishArc);
+            build().then(() => this.publishArc());
           }}
         />
       );

--- a/tests/components/App/App.spec.tsx
+++ b/tests/components/App/App.spec.tsx
@@ -66,7 +66,7 @@ function createActionSpies() {
   spies.build.mockImplementation(() => Promise.resolve());
   spies.run.mockImplementation(() => Promise.resolve());
   spies.publishArc.mockImplementation(() => Promise.resolve());
-  spies.saveProject.mockImplementation(() => {});
+  spies.saveProject.mockImplementation(async () => "fiddle-url");
   spies.notifyArcAboutFork.mockImplementation(() => {});
   spies.openProjectFiles.mockImplementation(() => {});
   spies.addFileTo.mockImplementation(() => {});
@@ -446,7 +446,7 @@ describe("Tests for App", () => {
         fork.mockRestore();
       });
       it("should create a fork", async () => {
-        Service.saveProject.mockImplementation(() => "fiddle-url");
+        Service.saveProject.mockImplementation(async () => "fiddle-url");
         const { pushStatus, popStatus, notifyArcAboutFork, restore } = createActionSpies();
         const embeddingParams = { type: EmbeddingType.None } as EmbeddingParams;
         const wrapper = setup({ embeddingParams });
@@ -459,7 +459,8 @@ describe("Tests for App", () => {
         restore();
       });
       it("should update the fiddle param in the url", async () => {
-        Service.saveProject.mockImplementation(() => "new-fiddle-url");
+        const { saveProject } = createActionSpies();
+        saveProject.mockImplementation(() => "new-fiddle-url");
         const embeddingParams = { type: EmbeddingType.None } as EmbeddingParams;
         const wrapper = await setup({ embeddingParams, fiddle: "fiddle-url" });
         await (wrapper.instance() as App).fork();

--- a/tests/unit/arc.spec.ts
+++ b/tests/unit/arc.spec.ts
@@ -24,19 +24,4 @@ describe("Arc tests", () => {
     }, "*");
     postMessage.mockRestore();
   });
-  it("should transform animation buffer to JSON on Arc.animationBufferToJSON", () => {
-    const rows = 36;
-    const cols = 44;
-    const frames = 1050;
-    const buffer = new ArrayBuffer(cols * rows * frames * 3);
-    const json = Arc.animationBufferToJSON(buffer, rows, cols, frames);
-    const frameCount = json.length;
-    const rowCount = json[0].length;
-    const colCount = json[0][0].length;
-    const last = json[1049][35][43];
-    expect(frameCount).toEqual(frames);
-    expect(rowCount).toEqual(rows);
-    expect(colCount).toEqual(cols);
-    expect(last).toEqual([0, 0, 0]);
-  });
 });


### PR DESCRIPTION
Thus ensuring that the fiddle ID we send to the Arch website is up-to-date with the latest changes.

Associated Issue: none

### Summary of Changes

This changes what happens when the "preview" buttons or shortcuts are used in the Arc embedding to always do a fork and notify the embedding website of the result.

Also changes how `fork` is implemented very slightly: instead of calling `Service.saveProject`, the `AppActions` module's `saveProject` export is used. This properly resets the app state's `isContentModified` flag. The fork only happens if that is set.

/cc @joshmarinacci