### PR TITLE
Update empty TypeScript template

### DIFF
--- a/templates/empty_ts/assembly/main.ts
+++ b/templates/empty_ts/assembly/main.ts
@@ -1,15 +1,7 @@
-@external("env", "sayHello")
 declare function sayHello(): void;
-
-declare namespace console {
-  function logi(value: i32): void;
-  function logf(value: f64): void;
-}
 
 sayHello();
 
 export function add(x: i32, y: i32): i32 {
   return x + y;
 }
-
-console.logi(add(1, 2));

--- a/templates/empty_ts/gulpfile.js
+++ b/templates/empty_ts/gulpfile.js
@@ -13,7 +13,9 @@ gulp.task("build", callback => {
 
 gulp.task("default", ["build"]);
 
-gulp.task("project:load", () => { // WebAssembly Studio only
+// This task is not required when running the project locally. Its purpose is to set up the
+// AssemblyScript compiler when a new project has been loaded in WebAssembly Studio.
+gulp.task("project:load", () => {
   const utils = require("@wasm/studio-utils");
   utils.eval(utils.project.getFile("setup.js").getData(), {
     logLn,

--- a/templates/empty_ts/package.json
+++ b/templates/empty_ts/package.json
@@ -7,7 +7,7 @@
   },
   "devDependencies": {
     "assemblyscript": "AssemblyScript/assemblyscript",
-    "gulp": "^3.9.1"
+    "gulp": "^3"
   },
   "wasmStudio": {
     "name": "Empty AssemblyScript Project",

--- a/templates/empty_ts/setup.js
+++ b/templates/empty_ts/setup.js
@@ -1,4 +1,5 @@
-// WebAssembly Studio only
+// This file is not required when running the project locally. Its purpose is to set up the
+// AssemblyScript compiler when a new project has been loaded in WebAssembly Studio.
 require.config({
   paths: {
     "binaryen": "https://rawgit.com/AssemblyScript/binaryen.js/master/index",

--- a/templates/empty_ts/src/main.js
+++ b/templates/empty_ts/src/main.js
@@ -1,16 +1,14 @@
 WebAssembly.instantiateStreaming(fetch("../out/main.wasm"), {
-  env: {
+  main: {
     sayHello() {
       console.log("Hello from WebAssembly!");
-    },
+    }
+  },
+  env: {
     abort(msg, file, line, column) {
       console.error("abort called at main.ts:" + line + ":" + column);
     }
   },
-  console: {
-    logi(value) { console.log('logi: ' + value); },
-    logf(value) { console.log('logf: ' + value); }
-  }
 }).then(result => {
   const exports = result.instance.exports;
   document.getElementById("container").innerText = "Result: " + exports.add(19, 23);


### PR DESCRIPTION
The default naming of module imports has changed on the AssemblyScript side lately. This PR updates the `empty_ts` template accordingly and removes a few lines of example code that are not ultimately necessary in an "empty" template.

Fixes #371