### PR TITLE
Issue 233 added missing wat keywords

### DIFF
--- a/src/languages/wat.ts
+++ b/src/languages/wat.ts
@@ -383,6 +383,11 @@ const MonarchDefinitions = {
     "get_global",
     "set_global",
 
+	"drop",
+	"select",
+	"memory.size",
+	"memory.grow",
+
     "current_memory",
     "grow_memory"
   ],

--- a/src/languages/wat.ts
+++ b/src/languages/wat.ts
@@ -383,10 +383,10 @@ const MonarchDefinitions = {
     "get_global",
     "set_global",
 
-	"drop",
-	"select",
-	"memory.size",
-	"memory.grow",
+    "drop",
+    "select",
+    "memory.size",
+    "memory.grow",
 
     "current_memory",
     "grow_memory"

--- a/tests/languages/wat.spec.ts
+++ b/tests/languages/wat.spec.ts
@@ -385,10 +385,10 @@ describe("Tests for Wat", () => {
         "tee_local",
         "get_global",
         "set_global",
-		"drop",
-		"select",
-		"memory.size",
-		"memory.grow",
+        "drop",
+        "select",
+        "memory.size",
+        "memory.grow",
         "current_memory",
         "grow_memory"
       ]);

--- a/tests/languages/wat.spec.ts
+++ b/tests/languages/wat.spec.ts
@@ -385,6 +385,10 @@ describe("Tests for Wat", () => {
         "tee_local",
         "get_global",
         "set_global",
+		"drop",
+		"select",
+		"memory.size",
+		"memory.grow",
         "current_memory",
         "grow_memory"
       ]);


### PR DESCRIPTION
Associated Issue: 233

Added missing keywords for WAT language highlighter.

Note: I am basing 'correct' keywords on this document:

https://webassembly.github.io/spec/core/text/

Tested in dev-server richedit control by typing new keywords into a new .wat file and observing they were correcetly highlighted.
