### PR TITLE
Fixed extra = for base64 encoding

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -132,7 +132,7 @@ export function base64EncodeBytes(bytes: Uint8Array) {
     a = (chunk & 252) >> 2; // 252 = (2^6 - 1) << 2
     // Set the 4 least significant bits to zero
     b = (chunk & 3) << 4; // 3 = 2^2 - 1
-    base64 += concat3(encodings[a], encodings[b], "===");
+    base64 += concat3(encodings[a], encodings[b], "==");
   } else if (byteRemainder === 2) {
     chunk = (bytes[mainLength] << 8) | bytes[mainLength + 1];
 

--- a/tests/utils/util.spec.ts
+++ b/tests/utils/util.spec.ts
@@ -50,14 +50,14 @@ describe("Tests for util.ts", () => {
   describe("base64EncodeBytes", () => {
     it("should encode bytes -> base64", () => {
       expect(util.base64EncodeBytes(new Uint8Array([1, 2, 3]))).toEqual("AQID");
-      expect(util.base64EncodeBytes(new Uint8Array([1, 2, 3, 4]))).toEqual("AQIDBA===");
+      expect(util.base64EncodeBytes(new Uint8Array([1, 2, 3, 4]))).toEqual("AQIDBA==");
       expect(util.base64EncodeBytes(new Uint8Array([1, 2, 3, 4, 5]))).toEqual("AQIDBAU=");
     });
   });
   describe("decodeRestrictedBase64ToBytes", () => {
     it("should decode base64 -> bytes", () => {
       expect(util.decodeRestrictedBase64ToBytes("AQID")).toEqual(new Uint8Array([1, 2, 3]));
-      expect(util.decodeRestrictedBase64ToBytes("AQIDBA===")).toEqual(new Uint8Array([1, 2, 3, 4]));
+      expect(util.decodeRestrictedBase64ToBytes("AQIDBA==")).toEqual(new Uint8Array([1, 2, 3, 4]));
       expect(util.decodeRestrictedBase64ToBytes("AQIDBAU=")).toEqual(new Uint8Array([1, 2, 3, 4, 5]));
     });
   });


### PR DESCRIPTION
Associated Issue: #400 

### Summary of Changes

Changes made in src/utils.ts
* Changed the number of "=" signs used for base64 encoding  when byte remainder is 1. 
Changed from 3 to 2.
* Modified the test file to accommodate for the changes above.

### Test Plan
Rewrote test by modifying the expected results in tests/utils/utils.spects.

All tests passing.