### PR TITLE
Remove MonacoUtils.expandTree(this.tree) call

### DIFF
--- a/src/components/DirectoryTree.tsx
+++ b/src/components/DirectoryTree.tsx
@@ -87,7 +87,6 @@ export class DirectoryTree extends React.Component<DirectoryTreeProps, {
       this.setState({ directory: props.directory });
     } else {
       this.tree.refresh();
-      MonacoUtils.expandTree(this.tree);
     }
   }
   private setContainer(container: HTMLDivElement) {


### PR DESCRIPTION
Associated Issue: #399 

Here's the contributing guide at https://github.com/wasdk/WebAssemblyStudio/wiki/Contributing

### Summary of Changes

I removed the MonacoUtils.expandTree(this.tree) call from 'DirectoryTree.tsx'. This call was causing the directory tree to expand whenever a user tried to edit any file. 
