### PR TITLE
Workaround for unpkg redirect issue

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,8 +37,8 @@ SOFTWARE.
             <!-- <script src="./node_modules/react-dom/umd/react-dom.development.js"></script> -->
 
 
-        <script crossorigin src="https://unpkg.com/react@16/umd/react.production.min.js"></script>
-        <script crossorigin src="https://unpkg.com/react-dom@16/umd/react-dom.production.min.js"></script>
+        <script crossorigin src="https://unpkg.com/react@16.7.0/umd/react.production.min.js"></script>
+        <script crossorigin src="https://unpkg.com/react-dom@16.7.0/umd/react-dom.production.min.js"></script>
 
         <!-- Main -->
 


### PR DESCRIPTION
### Summary of Changes

* fix paths for `unpkg` links for react bundles.

In several regions unpkg.com return `302` response. See more detail: https://github.com/unpkg/unpkg.com/issues/156