### PR TITLE
Use assemblyscript.github.io as CDN for AssemblyScript

### DIFF
--- a/templates/empty_ts/setup.js
+++ b/templates/empty_ts/setup.js
@@ -2,9 +2,9 @@
 // AssemblyScript compiler when a new project has been loaded in WebAssembly Studio.
 require.config({
   paths: {
-    "binaryen": "https://cdn.jsdelivr.net/gh/AssemblyScript/binaryen.js/index",
-    "assemblyscript": "https://cdn.jsdelivr.net/gh/AssemblyScript/assemblyscript/dist/assemblyscript",
-    "assemblyscript/bin/asc": "https://cdn.jsdelivr.net/gh/AssemblyScript/assemblyscript/dist/asc",
+    "binaryen": "https://assemblyscript.github.io/binaryen.js/index",
+    "assemblyscript": "https://assemblyscript.github.io/assemblyscript/dist/assemblyscript",
+    "assemblyscript/bin/asc": "https://assemblyscript.github.io/assemblyscript/dist/asc",
   }
 });
 logLn("Loading AssemblyScript compiler ...");


### PR DESCRIPTION
Switch our CDN from `jsdelvr` to `assemblyscript.github.io` for AssemblyScript template due to jsdelvr omitting latest version tag.

See more about issue:
https://github.com/jsdelivr/jsdelivr/issues/18128
https://github.com/AssemblyScript/binaryen.js/issues/8