### PR TITLE
Remove/disable export to gist

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -623,6 +623,7 @@
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
+      "optional": true,
       "requires": {
         "kind-of": "^3.0.2",
         "longest": "^1.0.1",
@@ -634,6 +635,7 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -834,7 +836,7 @@
         },
         "util": {
           "version": "0.10.3",
-          "resolved": "http://registry.npmjs.org/util/-/util-0.10.3.tgz",
+          "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
           "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
           "dev": true,
           "requires": {
@@ -1395,7 +1397,7 @@
     },
     "browserify-aes": {
       "version": "1.2.0",
-      "resolved": "http://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
       "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
       "dev": true,
       "requires": {
@@ -1432,7 +1434,7 @@
     },
     "browserify-rsa": {
       "version": "4.0.1",
-      "resolved": "http://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
       "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
       "dev": true,
       "requires": {
@@ -1485,7 +1487,7 @@
     },
     "buffer": {
       "version": "4.9.1",
-      "resolved": "http://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
       "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
       "dev": true,
       "requires": {
@@ -2086,7 +2088,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
@@ -2101,7 +2103,7 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "requires": {
@@ -2225,7 +2227,7 @@
     },
     "create-hash": {
       "version": "1.2.0",
-      "resolved": "http://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
       "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
       "dev": true,
       "requires": {
@@ -2238,7 +2240,7 @@
     },
     "create-hmac": {
       "version": "1.1.7",
-      "resolved": "http://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
       "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
       "dev": true,
       "requires": {
@@ -2719,7 +2721,7 @@
     },
     "diffie-hellman": {
       "version": "5.0.3",
-      "resolved": "http://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
       "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
       "dev": true,
       "requires": {
@@ -3070,7 +3072,7 @@
     },
     "es6-promisify": {
       "version": "5.0.0",
-      "resolved": "http://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
       "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
       "dev": true,
       "requires": {
@@ -3191,7 +3193,7 @@
     },
     "events": {
       "version": "1.1.1",
-      "resolved": "http://registry.npmjs.org/events/-/events-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
       "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=",
       "dev": true
     },
@@ -3968,7 +3970,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3989,12 +3992,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4009,17 +4014,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4136,7 +4144,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4148,6 +4157,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4162,6 +4172,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4169,12 +4180,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -4193,6 +4206,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4273,7 +4287,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4285,6 +4300,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4370,7 +4386,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4406,6 +4423,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4425,6 +4443,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4468,12 +4487,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -6859,7 +6880,8 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
       "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "loose-envify": {
       "version": "1.3.1",
@@ -7388,7 +7410,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
@@ -7837,7 +7859,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
@@ -7852,7 +7874,7 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "requires": {
@@ -7863,7 +7885,7 @@
     },
     "parse-asn1": {
       "version": "5.1.1",
-      "resolved": "http://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.1.tgz",
       "integrity": "sha512-KPx7flKXg775zZpnp9SxJlz00gTd4BmJ2yJufSc44gMCRrRQ7NSzAcSJQfifuOLgW6bEi+ftrALtsgALeB2Adw==",
       "dev": true,
       "requires": {
@@ -7983,7 +8005,7 @@
     },
     "pause-stream": {
       "version": "0.0.11",
-      "resolved": "http://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+      "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
       "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
       "dev": true,
       "requires": {
@@ -9620,7 +9642,7 @@
     },
     "sha.js": {
       "version": "2.4.11",
-      "resolved": "http://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
       "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
       "dev": true,
       "requires": {
@@ -10101,7 +10123,7 @@
     },
     "stream-browserify": {
       "version": "2.0.1",
-      "resolved": "http://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
       "integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
       "dev": true,
       "requires": {
@@ -10149,7 +10171,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
@@ -10164,7 +10186,7 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "requires": {
@@ -10752,7 +10774,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
@@ -10767,7 +10789,7 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "requires": {
@@ -11406,7 +11428,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -11419,7 +11441,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -376,20 +376,6 @@ export class App extends React.Component<AppProps, AppState> {
       notifyArcAboutFork(fiddle);
     }
   }
-  async gist(fileOrDirectory?: File) {
-    pushStatus("Exporting Project");
-    const target: File = fileOrDirectory || this.state.project.getModel();
-    const gistURI = await Service.exportToGist(target, this.state.fiddle);
-    popStatus();
-    if (gistURI) {
-      if (this.toastContainer) {
-        this.toastContainer.showToast(<span>"Gist Created!" <a href={gistURI} target="_blank" className="toast-span">Open in new tab.</a></span>);
-      }
-      console.log(`Gist created: ${gistURI}`);
-    } else {
-      console.log("Failed!");
-    }
-  }
   async download() {
     this.logLn("Downloading Project ...");
     const downloadService = await import("../utils/download");
@@ -473,16 +459,6 @@ export class App extends React.Component<AppProps, AppState> {
     }
     if (this.props.embeddingParams.type === EmbeddingType.None) {
       toolbarButtons.push(
-        <Button
-          key="CreateGist"
-          icon={<GoGist />}
-          label="Create Gist"
-          title="Create GitHub Gist from Project"
-          isDisabled={this.toolbarButtonsAreDisabled()}
-          onClick={() => {
-            this.gist();
-          }}
-        />,
         <Button
           key="Download"
           icon={<GoDesktopDownload />}
@@ -779,9 +755,6 @@ export class App extends React.Component<AppProps, AppState> {
             }}
             onNewDirectory={(directory: Directory) => {
               this.setState({ newDirectoryDialog: ModelRef.getRef(directory)});
-            }}
-            onCreateGist={(fileOrDirectory: File) => {
-                this.gist(fileOrDirectory);
             }}
           />
           <div className="fill">

--- a/src/components/DirectoryTree.tsx
+++ b/src/components/DirectoryTree.tsx
@@ -41,7 +41,6 @@ export interface DirectoryTreeProps {
   onClickFile?: (file: File) => void;
   onDoubleClickFile?: (file: File) => void;
   onUploadFile?: (directory: Directory) => void;
-  onCreateGist?: (fileOrDirectory: File) => void;
   onlyUploadActions?: boolean;
 }
 
@@ -188,13 +187,6 @@ export class DirectoryTree extends React.Component<DirectoryTreeProps, {
       }));
       actions.push(new MonacoUtils.Action("x", "Download", "octicon-cloud-download", true, () => {
         Service.download(file);
-      }));
-    }
-
-    // Create a gist from everything but binary
-    if (!isBinaryFileType(file.type)) {
-      this.props.onCreateGist && actions.push(new MonacoUtils.Action("x", "Create Gist", "octicon-gist", true, () => {
-        return this.props.onCreateGist(file as Directory);
       }));
     }
 

--- a/src/components/Workspace.tsx
+++ b/src/components/Workspace.tsx
@@ -41,7 +41,6 @@ export interface WorkspaceProps {
   onClickFile: (file: File) => void;
   onDoubleClickFile?: (file: File) => void;
   onUploadFile?: (directory: Directory) => void;
-  onCreateGist: (fileOrDirectory: File) => void;
 }
 
 export interface WorkSpaceState {
@@ -93,7 +92,6 @@ export class Workspace extends React.Component<WorkspaceProps, WorkSpaceState> {
             onMoveFile={this.props.onMoveFile}
             onClickFile={this.props.onClickFile}
             onDoubleClickFile={this.props.onDoubleClickFile}
-            onCreateGist={this.props.onCreateGist}
           />
         </Split>
       </div>

--- a/src/service.ts
+++ b/src/service.ts
@@ -318,16 +318,6 @@ export class Service {
     output.setData(result);
   }
 
-  static async createGist(json: object): Promise<string> {
-    const url = "https://api.github.com/gists";
-    const response = await fetch(url, {
-      method: "POST",
-      body: JSON.stringify(json),
-      headers: new Headers({ "Content-type": "application/json; charset=utf-8" })
-    });
-    return JSON.parse(await response.text()).html_url;
-  }
-
   static async loadJSON(uri: string): Promise<ILoadFiddleResponse> {
     const url = "https://webassembly-studio-fiddles.herokuapp.com/fiddle/" + uri;
     const response = await fetch(url, {
@@ -361,24 +351,6 @@ export class Service {
       }
     }
     return uri;
-  }
-
-  static async exportToGist(content: File, uri?: string): Promise<string> {
-    gaEvent("export", "Service", "gist");
-    const files: any = {};
-    function serialize(file: File) {
-      if (file instanceof Directory) {
-        file.mapEachFile((file: File) => serialize(file), true);
-      } else {
-        files[file.name] = {content: file.data};
-      }
-    }
-    serialize(content);
-    const json: any = { description: "source: https://webassembly.studio", public: true, files};
-    if (uri !== undefined) {
-      json["description"] = json["description"] + `/?f=${uri}`;
-    }
-    return await this.createGist(json);
   }
 
   static async saveProject(project: Project, openedFiles: string[][], uri?: string): Promise<string> {

--- a/tests/components/App/App.spec.tsx
+++ b/tests/components/App/App.spec.tsx
@@ -87,17 +87,14 @@ function createMockService() {
   const loadJSON = jest.fn();
   const loadFilesIntoProject = jest.fn();
   const saveProject = jest.fn();
-  const exportToGist = jest.fn();
   return {
     loadJSON,
     loadFilesIntoProject,
     saveProject,
-    exportToGist,
     clear: () => {
       loadJSON.mockClear();
       loadFilesIntoProject.mockClear();
       saveProject.mockClear();
-      exportToGist.mockClear();
     }
   };
 }
@@ -398,13 +395,12 @@ describe("Tests for App", () => {
     enum ButtonIndex {
       ViewWorkspace,
       Fork,
-      Gist,
       Download,
       Share,
       Build,
       Run,
       BuildAndRun,
-      Help = 9
+      Help = 8
     }
     enum UpdateButtonIndex {
       Update = 1
@@ -475,43 +471,6 @@ describe("Tests for App", () => {
         await (wrapper.instance() as App).fork();
         expect(notifyArcAboutFork).toHaveBeenCalledWith("fiddle-url");
         restore();
-      });
-    });
-    describe("Gist", () => {
-      it("should invoke App.gist when clicking the Gist button", () => {
-        const embeddingParams = { type: EmbeddingType.None } as EmbeddingParams;
-        const wrapper = setup({ embeddingParams });
-        const gist = jest.spyOn((wrapper.instance() as App), "gist");
-        gist.mockImplementation(() => {});
-        const toolbar = wrapper.find(Toolbar);
-        toolbar.find(Button).at(ButtonIndex.Gist).simulate("click");
-        expect(gist).toHaveBeenCalled();
-        gist.mockRestore();
-      });
-      it("should export the project to a Gist", async () => {
-        const { pushStatus, popStatus, restore } = createActionSpies();
-        const showToast = jest.fn();
-        App.prototype.toastContainer = { showToast } as any;
-        Service.exportToGist.mockImplementation(() => "gist-url");
-        const fiddle = "fiddle-url";
-        const embeddingParams = { type: EmbeddingType.None } as EmbeddingParams;
-        const wrapper = setup({ embeddingParams, fiddle });
-        await (wrapper.instance() as App).gist();
-        expect(pushStatus).toHaveBeenCalledWith("Exporting Project");
-        expect(Service.exportToGist).toHaveBeenCalledWith((wrapper.state() as any).project.getModel(), fiddle);
-        expect(popStatus).toHaveBeenCalled();
-        expect(shallow(showToast.mock.calls[1][0])).toContainReact(<span>"Gist Created!" <a href={"gist-url"} target="_blank" className="toast-span">Open in new tab.</a></span>);
-        App.prototype.toastContainer = undefined;
-        restore();
-      });
-      it("should export the provided file to a Gist", async () => {
-        Service.exportToGist.mockImplementation(() => "gist-url");
-        const file = new File("file", FileType.JavaScript);
-        const fiddle = "fiddle-url";
-        const embeddingParams = { type: EmbeddingType.None } as EmbeddingParams;
-        const wrapper = setup({ embeddingParams, fiddle });
-        await (wrapper.instance() as App).gist(file);
-        expect(Service.exportToGist).toHaveBeenCalledWith(file, fiddle);
       });
     });
     describe("Download", () => {
@@ -970,18 +929,6 @@ describe("Tests for App", () => {
       const directory = new Directory("src");
       onNewDirectory(directory);
       expect(wrapper).toHaveState({ newDirectoryDialog: ModelRef.getRef(directory) });
-    });
-    it("should handle onCreateGist", () => {
-      const embeddingParams = { type: EmbeddingType.None } as EmbeddingParams;
-      const wrapper = setup({ embeddingParams });
-      const gist = jest.spyOn((wrapper.instance() as App), "gist");
-      gist.mockImplementation(() => {});
-      const workspace = wrapper.find(Workspace);
-      const onCreateGist = workspace.prop("onCreateGist");
-      const file = new File("file", FileType.JavaScript);
-      onCreateGist(file);
-      expect(gist).toHaveBeenCalledWith(file);
-      gist.mockRestore();
     });
   });
   describe("Console", () => {

--- a/tests/components/App/__snapshots__/App.spec.tsx.snap
+++ b/tests/components/App/__snapshots__/App.spec.tsx.snap
@@ -37,7 +37,6 @@ exports[`Tests for App render should render correctly (arc) 1`] = `
       <Workspace
         file={null}
         onClickFile={[Function]}
-        onCreateGist={[Function]}
         onDeleteFile={[Function]}
         onDoubleClickFile={[Function]}
         onEditFile={[Function]}
@@ -299,7 +298,6 @@ exports[`Tests for App render should render correctly (embedded) 1`] = `
       <Workspace
         file={null}
         onClickFile={[Function]}
-        onCreateGist={[Function]}
         onDeleteFile={[Function]}
         onDoubleClickFile={[Function]}
         onEditFile={[Function]}
@@ -558,7 +556,6 @@ exports[`Tests for App render should render correctly (fiddle) 1`] = `
       <Workspace
         file={null}
         onClickFile={[Function]}
-        onCreateGist={[Function]}
         onDeleteFile={[Function]}
         onDoubleClickFile={[Function]}
         onEditFile={[Function]}
@@ -813,7 +810,6 @@ exports[`Tests for App render should render correctly (update) 1`] = `
       <Workspace
         file={null}
         onClickFile={[Function]}
-        onCreateGist={[Function]}
         onDeleteFile={[Function]}
         onDoubleClickFile={[Function]}
         onEditFile={[Function]}
@@ -955,14 +951,6 @@ exports[`Tests for App render should render correctly (update) 1`] = `
               label="Fork"
               onClick={[Function]}
               title="Fork Project"
-            />
-            <Button
-              icon={<GoGist />}
-              isDisabled={false}
-              key="CreateGist"
-              label="Create Gist"
-              onClick={[Function]}
-              title="Create GitHub Gist from Project"
             />
             <Button
               icon={<GoDesktopDownload />}
@@ -1125,7 +1113,6 @@ exports[`Tests for App render should render correctly 1`] = `
       <Workspace
         file={null}
         onClickFile={[Function]}
-        onCreateGist={[Function]}
         onDeleteFile={[Function]}
         onDoubleClickFile={[Function]}
         onEditFile={[Function]}
@@ -1259,14 +1246,6 @@ exports[`Tests for App render should render correctly 1`] = `
               label="Fork"
               onClick={[Function]}
               title="Fork Project"
-            />
-            <Button
-              icon={<GoGist />}
-              isDisabled={false}
-              key="CreateGist"
-              label="Create Gist"
-              onClick={[Function]}
-              title="Create GitHub Gist from Project"
             />
             <Button
               icon={<GoDesktopDownload />}

--- a/tests/components/DirectoryTree/DirectoryTree.spec.tsx
+++ b/tests/components/DirectoryTree/DirectoryTree.spec.tsx
@@ -46,7 +46,6 @@ const Actions = {
   ViewAsBinary: { id: "x", label: "View as Binary", cssClass: "octicon-file-binary", enabled: true },
   Twiggy: { id: "x", label: "Twiggy", cssClass: "octicon-file-binary", enabled: true },
   Download: { id: "x", label: "Download", cssClass: "octicon-cloud-download", enabled: true },
-  Gist: { id: "x", label: "Create Gist", cssClass: "octicon-gist", enabled: true },
   Delete: { id: "x", label: "Delete", cssClass: "octicon-x", enabled: true },
   Edit: { id: "x", label: "Edit", cssClass: "octicon-pencil", enabled: true },
   NewFile: { id: "x", label: "New File", cssClass: "octicon-file-add", enabled: true },
@@ -373,29 +372,6 @@ describe("Tests for DirectoryTree", () => {
         const actions = getActions(file);
         expect(actions).toHaveLength(1);
         expect(actions[0]).toMatchObject(Actions.Download);
-        wrapper.unmount();
-      });
-    });
-    describe("Gist", () => {
-      it("should add the gist action if passing the onCreateGist prop", () => {
-        const onCreateGist = jest.fn();
-        const { wrapper, getActions } = setup({ onCreateGist });
-        const file = new File("file", FileType.JavaScript);
-        const actions = getActions(file);
-        actions.forEach(action => action.actionCallback());
-        expect(actions).toHaveLength(2);
-        expect(actions[0]).toMatchObject(Actions.Download);
-        expect(actions[1]).toMatchObject(Actions.Gist);
-        expect(onCreateGist).toHaveBeenCalledWith(file);
-        wrapper.unmount();
-      });
-      it("should never add the gist action for binary file types", () => {
-        const onCreateGist = jest.fn();
-        const { wrapper, getActions } = setup({ onCreateGist });
-        const file = new File("file", FileType.Wasm);
-        const actions = getActions(file);
-        const gistActions = actions.filter(action => action.label === "Create Gist");
-        expect(gistActions).toHaveLength(0);
         wrapper.unmount();
       });
     });

--- a/tests/components/Workspace/Workspace.spec.tsx
+++ b/tests/components/Workspace/Workspace.spec.tsx
@@ -34,7 +34,6 @@ describe("Tests for Workspace", () => {
     const onMoveFile = jest.fn();
     const onClickFile = jest.fn();
     const onDoubleClickFile = jest.fn();
-    const onCreateGist = jest.fn();
     const { wrapper, project, fileA } = setup({
       onNewFile,
       onNewDirectory,
@@ -43,8 +42,7 @@ describe("Tests for Workspace", () => {
       onUploadFile,
       onMoveFile,
       onClickFile,
-      onDoubleClickFile,
-      onCreateGist
+      onDoubleClickFile
     });
     const header = wrapper.find(Header);
     const split = wrapper.find(Split);
@@ -62,7 +60,6 @@ describe("Tests for Workspace", () => {
     expect(directoryTree).toHaveProp("onMoveFile", onMoveFile);
     expect(directoryTree).toHaveProp("onClickFile", onClickFile);
     expect(directoryTree).toHaveProp("onDoubleClickFile", onDoubleClickFile);
-    expect(directoryTree).toHaveProp("onCreateGist", onCreateGist);
   });
   it("should update state when split changes", () => {
     const { wrapper } = setup();

--- a/tests/services/Service.spec.ts
+++ b/tests/services/Service.spec.ts
@@ -293,21 +293,6 @@ describe("Tests for Service", () => {
       assembleWat.mockRestore();
     });
   });
-  describe("Service.createGist", () => {
-    it("should create a new gist", async () => {
-      const text = jest.fn(() => Promise.resolve(JSON.stringify({ html_url: "gist-url" })));
-      const { restore } = mockFetch({ text });
-      const json = { a: 1, b: 2 };
-      const result = await Service.createGist(json);
-      expect(window.fetch).toHaveBeenCalledWith("https://api.github.com/gists", {
-        method: "POST",
-        body: JSON.stringify(json),
-        headers: { "Content-type": "application/json; charset=utf-8" }
-      });
-      expect(result).toEqual("gist-url");
-      restore();
-    });
-  });
   describe("Service.loadJSON", () => {
     it("should load a fiddle from the provided uri", async () => {
       const json = jest.fn(() => Promise.resolve("response"));
@@ -355,59 +340,6 @@ describe("Tests for Service", () => {
     it("should handle cases where no fiddle uri is present", () => {
       window.history.pushState({}, "", "https://webassembly.studio/");
       expect(Service.parseFiddleURI()).toEqual("");
-    });
-  });
-  describe("Service.exportToGist", () => {
-    it("should provide analytics to google (gaEvent)", async () => {
-      const createGist = jest.spyOn(Service, "createGist");
-      createGist.mockImplementation(() => {});
-      gaEvent.mockClear();
-      const file = new File("file", FileType.JavaScript);
-      await Service.exportToGist(file);
-      expect(gaEvent).toHaveBeenCalledWith("export", "Service", "gist");
-      createGist.mockRestore();
-    });
-    it("should export the provided file to a gist", async () => {
-      const createGist = jest.spyOn(Service, "createGist");
-      createGist.mockImplementation(() => {});
-      const file = new File("file.js", FileType.JavaScript);
-      file.setData("file-data");
-      await Service.exportToGist(file);
-      expect(createGist).toHaveBeenCalledWith({
-        description: "source: https://webassembly.studio",
-        public: true,
-        files: { "file.js": { content: "file-data" }}
-      });
-      createGist.mockRestore();
-    });
-    it("should export the provided directory to a gist", async () => {
-      const createGist = jest.spyOn(Service, "createGist");
-      createGist.mockImplementation(() => {});
-      const directory = new Directory("src");
-      const fileA = directory.newFile("fileA.js", FileType.JavaScript);
-      const fileB = directory.newFile("fileB.js", FileType.JavaScript);
-      fileA.setData("file-data");
-      fileB.isTransient = true;
-      await Service.exportToGist(directory);
-      expect(createGist).toHaveBeenCalledWith({
-        description: "source: https://webassembly.studio",
-        public: true,
-        files: { "fileA.js": { content: "file-data" }}
-      });
-      createGist.mockRestore();
-    });
-    it("should be possible to provide a fiddle url as an optional parameter", async () => {
-      const createGist = jest.spyOn(Service, "createGist");
-      createGist.mockImplementation(() => {});
-      const file = new File("file.js", FileType.JavaScript);
-      file.setData("file-data");
-      await Service.exportToGist(file, "fiddle-uri");
-      expect(createGist).toHaveBeenCalledWith({
-        description: "source: https://webassembly.studio/?f=fiddle-uri",
-        public: true,
-        files: { "file.js": { content: "file-data" }}
-      });
-      createGist.mockRestore();
     });
   });
   describe("Service.saveProject", () => {


### PR DESCRIPTION
Associated Issue: #423

Using github.com authentication with this type of project is problematic. The design of the webassemby studio relied on github.com to *not* authenticate anything/anyone during gist creation. Let's remove entire functionality.