### PR TITLE
Switched to `@latest` version tag for AssemblyScript's template

### DIFF
--- a/templates/empty_ts/setup.js
+++ b/templates/empty_ts/setup.js
@@ -2,9 +2,9 @@
 // AssemblyScript compiler when a new project has been loaded in WebAssembly Studio.
 require.config({
   paths: {
-    "binaryen": "https://cdn.jsdelivr.net/npm/binaryen@nightly/index",
-    "assemblyscript": "https://cdn.jsdelivr.net/npm/assemblyscript@nightly/dist/assemblyscript",
-    "assemblyscript/bin/asc": "https://cdn.jsdelivr.net/npm/assemblyscript@nightly/dist/asc",
+    "binaryen": "https://cdn.jsdelivr.net/npm/binaryen@latest/index",
+    "assemblyscript": "https://cdn.jsdelivr.net/npm/assemblyscript@latest/dist/assemblyscript",
+    "assemblyscript/bin/asc": "https://cdn.jsdelivr.net/npm/assemblyscript@latest/dist/asc",
   }
 });
 logLn("Loading AssemblyScript compiler ...");


### PR DESCRIPTION
We don't use `@nightly` channel any more due to switching to semantic-release
