### PR TITLE
Remove defunct link from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ WebAssembly Studio
 ====
 [![Build Status](https://travis-ci.org/wasdk/WebAssemblyStudio.svg?branch=master)](https://travis-ci.org/wasdk/WebAssemblyStudio) [![Coverage Status](https://coveralls.io/repos/github/wasdk/WebAssemblyStudio/badge.svg)](https://coveralls.io/github/wasdk/WebAssemblyStudio) [![Maintainance Status](https://img.shields.io/badge/maintained-seldom-yellowgreen.svg)](https://github.com/wasdk/WebAssemblyStudio/issues/381)
 
-This repository contains the [WebAssembly Studio](https://webassembly.studio) website source code.
+This repository contains the (defunct) WebAssembly Studio website source code.
 
 Running your own local copy of the website
 ===


### PR DESCRIPTION
The old WebAssembly Studio url now redirects to various things that are not WebAssembly studio.